### PR TITLE
Gitignore repo-local .sediment.db files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,5 +22,8 @@ Thumbs.db
 
 # Build
 dist/
-coverage.out
-cov.out
+
+# Agent memory (repo-local, not source)
+.sediment.db
+.sediment.db-wal
+.sediment.db-shm


### PR DESCRIPTION
## Summary

Exclude the agent memory database and its SQLite journal files from version control. The `.sediment.db` is per-repo local context (created by the `sediment` CLI), not project source.