### PR TITLE
Add hardness-based decay, auto-erosion, and opencode plugin

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -16,7 +16,7 @@ go vet ./...
 echo "==> tests + coverage"
 go test -race -coverprofile=coverage.out -covermode=atomic ./...
 
-UNCOVERED=$(go tool cover -func=coverage.out | grep -v '100.0%' | grep -v '^total:' | grep -v '\.go:[0-9]*:	main	')
+UNCOVERED=$(go tool cover -func=coverage.out | grep -v '100.0%' | grep -v '^total:' | grep -v '\.go:[0-9]*:	main	' || true)
 if [ -n "$UNCOVERED" ]; then
     echo ""
     echo "FAIL: functions not at 100% coverage:"

--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,9 @@ Thumbs.db
 # Build
 dist/
 
+# Plugin node_modules
+.opencode/node_modules/
+
 # Agent memory (repo-local, not source)
 .sediment.db
 .sediment.db-wal

--- a/.opencode/package-lock.json
+++ b/.opencode/package-lock.json
@@ -1,0 +1,413 @@
+{
+  "name": ".opencode",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "dependencies": {
+        "@opencode-ai/plugin": "latest"
+      },
+      "devDependencies": {
+        "@types/node": "^25.6.0",
+        "typescript": "^6.0.3"
+      }
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-darwin-arm64": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-arm64/-/msgpackr-extract-darwin-arm64-3.0.3.tgz",
+      "integrity": "sha512-QZHtlVgbAdy2zAqNA9Gu1UpIuI8Xvsd1v8ic6B2pZmeFnFcMWiPLfWXh7TVw4eGEZ/C9TH281KwhVoeQUKbyjw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-darwin-x64": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-x64/-/msgpackr-extract-darwin-x64-3.0.3.tgz",
+      "integrity": "sha512-mdzd3AVzYKuUmiWOQ8GNhl64/IoFGol569zNRdkLReh6LRLHOXxU4U8eq0JwaD8iFHdVGqSy4IjFL4reoWCDFw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-linux-arm": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-arm/-/msgpackr-extract-linux-arm-3.0.3.tgz",
+      "integrity": "sha512-fg0uy/dG/nZEXfYilKoRe7yALaNmHoYeIoJuJ7KJ+YyU2bvY8vPv27f7UKhGRpY6euFYqEVhxCFZgAUNQBM3nw==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-linux-arm64": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-arm64/-/msgpackr-extract-linux-arm64-3.0.3.tgz",
+      "integrity": "sha512-YxQL+ax0XqBJDZiKimS2XQaf+2wDGVa1enVRGzEvLLVFeqa5kx2bWbtcSXgsxjQB7nRqqIGFIcLteF/sHeVtQg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-linux-x64": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-x64/-/msgpackr-extract-linux-x64-3.0.3.tgz",
+      "integrity": "sha512-cvwNfbP07pKUfq1uH+S6KJ7dT9K8WOE4ZiAcsrSes+UY55E/0jLYc+vq+DO7jlmqRb5zAggExKm0H7O/CBaesg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-win32-x64": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-win32-x64/-/msgpackr-extract-win32-x64-3.0.3.tgz",
+      "integrity": "sha512-x0fWaQtYp4E6sktbsdAqnehxDgEc/VwM7uLsRCYWaiGu0ykYdZPiS8zCWdnjHwyiumousxfBm4SO31eXqwEZhQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@opencode-ai/plugin": {
+      "version": "1.14.19",
+      "resolved": "https://registry.npmjs.org/@opencode-ai/plugin/-/plugin-1.14.19.tgz",
+      "integrity": "sha512-g0C8Viocybmet7nBqJK/1xrQnacRS1f30VmqRTPScPmWz+4knIZzc2TEQp8+920sN8rB6BuoGwfBUVRXJmavhQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@opencode-ai/sdk": "1.14.19",
+        "effect": "4.0.0-beta.48",
+        "zod": "4.1.8"
+      },
+      "peerDependencies": {
+        "@opentui/core": ">=0.1.101",
+        "@opentui/solid": ">=0.1.101"
+      },
+      "peerDependenciesMeta": {
+        "@opentui/core": {
+          "optional": true
+        },
+        "@opentui/solid": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@opencode-ai/sdk": {
+      "version": "1.14.19",
+      "resolved": "https://registry.npmjs.org/@opencode-ai/sdk/-/sdk-1.14.19.tgz",
+      "integrity": "sha512-9sTGsi8/HlBBeaWfsUjdJ2yi/SqpRvqSld0IFXc3ldaPb1w1uIPvgCGzhlHYQtqatXxSaX5lTN7zpudMaE21aw==",
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "7.0.6"
+      }
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "25.6.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
+      "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.19.0"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/effect": {
+      "version": "4.0.0-beta.48",
+      "resolved": "https://registry.npmjs.org/effect/-/effect-4.0.0-beta.48.tgz",
+      "integrity": "sha512-MMAM/ZabuNdNmgXiin+BAanQXK7qM8mlt7nfXDoJ/Gn9V8i89JlCq+2N0AiWmqFLXjGLA0u3FjiOjSOYQk5uMw==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "fast-check": "^4.6.0",
+        "find-my-way-ts": "^0.1.6",
+        "ini": "^6.0.0",
+        "kubernetes-types": "^1.30.0",
+        "msgpackr": "^1.11.9",
+        "multipasta": "^0.2.7",
+        "toml": "^4.1.1",
+        "uuid": "^13.0.0",
+        "yaml": "^2.8.3"
+      }
+    },
+    "node_modules/fast-check": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-4.7.0.tgz",
+      "integrity": "sha512-NsZRtqvSSoCP0HbNjUD+r1JH8zqZalyp6gLY9e7OYs7NK9b6AHOs2baBFeBG7bVNsuoukh89x2Yg3rPsul8ziQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "pure-rand": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=12.17.0"
+      }
+    },
+    "node_modules/find-my-way-ts": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/find-my-way-ts/-/find-my-way-ts-0.1.6.tgz",
+      "integrity": "sha512-a85L9ZoXtNAey3Y6Z+eBWW658kO/MwR7zIafkIUPUMf3isZG0NCs2pjW2wtjxAKuJPxMAsHUIP4ZPGv0o5gyTA==",
+      "license": "MIT"
+    },
+    "node_modules/ini": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-6.0.0.tgz",
+      "integrity": "sha512-IBTdIkzZNOpqm7q3dRqJvMaldXjDHWkEDfrwGEQTs5eaQMWV+djAhR+wahyNNMAa+qpbDUhBMVt4ZKNwpPm7xQ==",
+      "license": "ISC",
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/kubernetes-types": {
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/kubernetes-types/-/kubernetes-types-1.30.0.tgz",
+      "integrity": "sha512-Dew1okvhM/SQcIa2rcgujNndZwU8VnSapDgdxlYoB84ZlpAD43U6KLAFqYo17ykSFGHNPrg0qry0bP+GJd9v7Q==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/msgpackr": {
+      "version": "1.11.10",
+      "resolved": "https://registry.npmjs.org/msgpackr/-/msgpackr-1.11.10.tgz",
+      "integrity": "sha512-iCZNq+HszvF+fC3anCm4nBmWEnbeIAfpDs6IStAEKhQ2YSgkjzVG2FF9XJqwwQh5bH3N9OUTUt4QwVN6MLMLtA==",
+      "license": "MIT",
+      "optionalDependencies": {
+        "msgpackr-extract": "^3.0.2"
+      }
+    },
+    "node_modules/msgpackr-extract": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/msgpackr-extract/-/msgpackr-extract-3.0.3.tgz",
+      "integrity": "sha512-P0efT1C9jIdVRefqjzOQ9Xml57zpOXnIuS+csaB4MdZbTdmGDLo8XhzBG1N7aO11gKDDkJvBLULeFTo46wwreA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "node-gyp-build-optional-packages": "5.2.2"
+      },
+      "bin": {
+        "download-msgpackr-prebuilds": "bin/download-prebuilds.js"
+      },
+      "optionalDependencies": {
+        "@msgpackr-extract/msgpackr-extract-darwin-arm64": "3.0.3",
+        "@msgpackr-extract/msgpackr-extract-darwin-x64": "3.0.3",
+        "@msgpackr-extract/msgpackr-extract-linux-arm": "3.0.3",
+        "@msgpackr-extract/msgpackr-extract-linux-arm64": "3.0.3",
+        "@msgpackr-extract/msgpackr-extract-linux-x64": "3.0.3",
+        "@msgpackr-extract/msgpackr-extract-win32-x64": "3.0.3"
+      }
+    },
+    "node_modules/multipasta": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/multipasta/-/multipasta-0.2.7.tgz",
+      "integrity": "sha512-KPA58d68KgGil15oDqXjkUBEBYc00XvbPj5/X+dyzeo/lWm9Nc25pQRlf1D+gv4OpK7NM0J1odrbu9JNNGvynA==",
+      "license": "MIT"
+    },
+    "node_modules/node-gyp-build-optional-packages": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/node-gyp-build-optional-packages/-/node-gyp-build-optional-packages-5.2.2.tgz",
+      "integrity": "sha512-s+w+rBWnpTMwSFbaE0UXsRlg7hU4FjekKU4eyAih5T8nJuNZT1nNsskXpxmeqSK9UzkBl6UgRlnKc8hz8IEqOw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "detect-libc": "^2.0.1"
+      },
+      "bin": {
+        "node-gyp-build-optional-packages": "bin.js",
+        "node-gyp-build-optional-packages-optional": "optional.js",
+        "node-gyp-build-optional-packages-test": "build-test.js"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pure-rand": {
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-8.4.0.tgz",
+      "integrity": "sha512-IoM8YF/jY0hiugFo/wOWqfmarlE6J0wc6fDK1PhftMk7MGhVZl88sZimmqBBFomLOCSmcCCpsfj7wXASCpvK9A==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/toml": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/toml/-/toml-4.1.1.tgz",
+      "integrity": "sha512-EBJnVBr3dTXdA89WVFoAIPUqkBjxPMwRqsfuo1r240tKFHXv3zgca4+NJib/h6TyvGF7vOawz0jGuryJCdNHrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.19.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
+      "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/uuid": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-13.0.0.tgz",
+      "integrity": "sha512-XQegIaBTVUjSHliKqcnFqYypAd4S+WCYt5NIeRs6w/UAry7z8Y9j5ZwRRL4kzq9U3sD6v+85er9FvkEaBpji2w==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist-node/bin/uuid"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/yaml": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
+      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.1.8.tgz",
+      "integrity": "sha512-5R1P+WwQqmmMIEACyzSvo4JXHY5WiAFHRMg+zBZKgKS+Q1viRa0C1hmUKtHltoIFKtIdki3pRxkmpP74jnNYHQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    }
+  }
+}

--- a/.opencode/package.json
+++ b/.opencode/package.json
@@ -1,0 +1,10 @@
+{
+  "private": true,
+  "dependencies": {
+    "@opencode-ai/plugin": "latest"
+  },
+  "devDependencies": {
+    "@types/node": "^25.6.0",
+    "typescript": "^6.0.3"
+  }
+}

--- a/.opencode/plugins/sediment.ts
+++ b/.opencode/plugins/sediment.ts
@@ -1,0 +1,131 @@
+import type { Plugin } from "@opencode-ai/plugin"
+import type { Part } from "@opencode-ai/sdk"
+import { tool } from "@opencode-ai/plugin"
+
+const DEPOSIT_INSTRUCTION = `## Memory Protocol
+You have persistent memory via the \`sediment_deposit\` tool. After each response,
+consider: did I learn something about the user, project, or codebase worth
+remembering in a future session? If yes, call sediment_deposit with:
+- content: concise single-statement fact
+- hardness: 1-3 for ephemeral, 4-6 for decisions/preferences, 7-10 for conventions/patterns
+- tags: relevant categories
+- supersedes_id: ID of contradicted memory (if applicable)
+
+Most turns require zero deposits. Only deposit genuinely new, reusable knowledge.
+Current memories are available in context — check for contradictions before depositing.`
+
+export const SedimentPlugin: Plugin = async ({ $, directory }) => {
+  const dbPath = `${directory}/.sediment.db`
+
+  const sediment = async (args: string[]) => {
+    const escaped = args.map((a) => $.escape(a))
+    const escapedDb = $.escape(dbPath)
+    const result =
+      await $`sediment ${escaped.join(" ")} --db ${escapedDb}`.quiet()
+    return result.text().trim()
+  }
+
+  let activeMemories: string | null = null
+
+  try {
+    await sediment(["erode", "--auto"])
+    activeMemories = await sediment(["strata"])
+  } catch {
+    // sediment not initialized or not installed
+  }
+
+  return {
+    "chat.message": async (_input, output) => {
+      output.parts.push({
+        type: "text",
+        text: DEPOSIT_INSTRUCTION,
+      } as Part)
+    },
+
+    "experimental.session.compacting": async (_input, output) => {
+      try {
+        activeMemories = await sediment(["strata"])
+      } catch {
+        // fall back to cached
+      }
+      if (activeMemories) {
+        output.context.push(
+          `## Sediment Memories (persistent across sessions)\n${activeMemories}`,
+        )
+      }
+    },
+
+    tool: {
+      sediment_deposit: tool({
+        description: [
+          "Store a memory for future sessions. Use this after learning something worth",
+          "remembering about the user, project, or codebase.",
+          "",
+          "Hardness uses Mohs scale (1-10):",
+          "  1-3 (Talc-Calcite): situational, one-off comments, ephemeral context",
+          "  4-6 (Fluorite-Feldspar): decisions, preferences, architectural choices",
+          "  7-10 (Quartz-Diamond): conventions, patterns, testing approach, team rules",
+          "",
+          "Contradiction handling: if the new memory contradicts an existing one,",
+          "set supersedes_id to the ID of the old memory. The old memory will be",
+          "archived and replaced.",
+        ].join("\n"),
+        args: {
+          content: tool.schema.string(),
+          tags: tool.schema.array(tool.schema.string()).optional(),
+          hardness: tool.schema.number().min(1).max(10).optional(),
+          supersedes_id: tool.schema.string().optional(),
+        },
+        async execute(args) {
+          if (args.supersedes_id) {
+            try {
+              await sediment([
+                "resolve",
+                "--action",
+                "supersede",
+                "--id",
+                args.supersedes_id,
+                "--content",
+                args.content,
+              ])
+              return `Superseded memory ${args.supersedes_id} with: ${args.content}`
+            } catch (e) {
+              return `Failed to supersede: ${e}`
+            }
+          }
+
+          const depositArgs = [
+            "deposit",
+            "--content",
+            args.content,
+            "--hardness",
+            String(args.hardness ?? 5),
+          ]
+          if (args.tags?.length) {
+            depositArgs.push("--tags", args.tags.join(","))
+          }
+          try {
+            return await sediment(depositArgs)
+          } catch (e) {
+            return `Failed to deposit: ${e}`
+          }
+        },
+      }),
+
+      sediment_recall: tool({
+        description:
+          "Retrieve all active and dormant memories from previous sessions. " +
+          "Use at the start of a session if memories were not auto-loaded, " +
+          "or to refresh context mid-session.",
+        args: {},
+        async execute() {
+          try {
+            return await sediment(["strata"])
+          } catch (e) {
+            return `Failed to recall: ${e}`
+          }
+        },
+      }),
+    },
+  }
+}

--- a/cmd/sediment/main.go
+++ b/cmd/sediment/main.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"slices"
+	"strconv"
 	"strings"
 	"time"
 
@@ -51,14 +52,15 @@ Show memory counts grouped by lifecycle state (active, dormant, archived).
 
 Output: {"total":N,"active":N,"dormant":N,"archived":N,"path":"..."}`,
 
-	"deposit": `Usage: sediment deposit --content <text> [--tags <a,b,c>] [--source <origin>] [--db <path>]
+	"deposit": `Usage: sediment deposit --content <text> [--tags <a,b,c>] [--source <origin>] [--hardness <1-10>] [--db <path>]
 
 Store a new memory. Confidence starts at 1.0, state at active.
 
 Flags:
-  --content  (required) The text content of the memory
-  --tags     Comma-separated labels for categorisation
-  --source   Where the memory came from (e.g. conversation ID)
+  --content   (required) The text content of the memory
+  --tags      Comma-separated labels for categorisation
+  --source    Where the memory came from (e.g. conversation ID)
+  --hardness  Durability on the Mohs scale: 1 (talc, ephemeral) to 10 (diamond, permanent). Default: 5
 
 Output: the full memory object as JSON`,
 
@@ -82,11 +84,18 @@ Flags:
 
 Output: {"memory":{...},"decayed_confidence":N,"boosted_confidence":N,"state":"..."}`,
 
-	"erode": `Usage: sediment erode [--db <path>]
+	"erode": `Usage: sediment erode [--auto] [--db <path>]
 
-Run a decay cycle across all memories. Applies exponential time-based decay
+Run a decay cycle. Applies exponential time-based decay modulated by hardness
 to each memory's confidence and transitions memories between lifecycle states:
   active (≥0.4) → dormant (≥0.1) → archived (<0.1)
+
+Flags:
+  --auto  Automatic mode: tracks sessions, runs quick/standard/deep erosion
+          based on active memory count and session number.
+          - quick:    every session, active memories only
+          - standard: when ≥100 active memories, includes dormant
+          - deep:     every 10th standard erosion, all memories
 
 All updates run in a single transaction.
 
@@ -142,6 +151,8 @@ type storeI interface {
 	Delete(id string) error
 	RunInTx(fn func() error) error
 	Close() error
+	GetMeta(key string) (string, error)
+	SetMeta(key, value string) error
 }
 
 // openFunc is the function used to open a database. Overridable for tests.
@@ -322,6 +333,18 @@ func cmdDeposit(args []string, w io.Writer) error {
 		}
 	}
 
+	hardness := model.HardnessDefault
+	if raw := flagValue(args, "--hardness"); raw != "" {
+		n, err := strconv.Atoi(raw)
+		if err != nil {
+			return fmt.Errorf("--hardness must be a number: %w", err)
+		}
+		hardness = model.Hardness(n)
+		if err := hardness.Validate(); err != nil {
+			return err
+		}
+	}
+
 	db, _, err := openAndMigrate(args)
 	if err != nil {
 		return err
@@ -340,6 +363,7 @@ func cmdDeposit(args []string, w io.Writer) error {
 		LastAccessedAt: now,
 		Tags:           tags,
 		Source:         source,
+		Hardness:       hardness,
 	}
 
 	if err := db.Insert(m); err != nil {
@@ -418,18 +442,99 @@ func cmdExcavate(args []string, w io.Writer) error {
 	})
 }
 
+const (
+	metaSessionCount = "session_count"
+	metaLastErode    = "last_erode_at"
+
+	autoErodeActiveThreshold = 100
+	deepErodeEveryN          = 10
+)
+
 func cmdErode(args []string, w io.Writer) error {
+	auto := slices.Contains(args, "--auto")
+
 	db, _, err := openAndMigrate(args)
 	if err != nil {
 		return err
 	}
 	defer db.Close()
 
-	all, err := db.ListAll()
+	if auto {
+		return autoErode(db, w)
+	}
+	return erodeAll(db, w)
+}
+
+func autoErode(db storeI, w io.Writer) error {
+	sessionCount := bumpSession(db)
+
+	active, err := db.ListByState(model.StateActive)
 	if err != nil {
-		return fmt.Errorf("erode list: %w", err)
+		return fmt.Errorf("erode list active: %w", err)
 	}
 
+	needsStandard := len(active) >= autoErodeActiveThreshold
+	needsDeep := needsStandard && sessionCount%deepErodeEveryN == 0
+
+	level := "quick"
+	if needsDeep {
+		level = "deep"
+	} else if needsStandard {
+		level = "standard"
+	}
+
+	result, err := runErosion(db, level)
+	if err != nil {
+		return err
+	}
+	result["level"] = level
+	result["session"] = sessionCount
+	result["active_count"] = len(active)
+
+	db.SetMeta(metaLastErode, timeNow().Format(time.RFC3339))
+
+	return writeJSON(w, result)
+}
+
+func bumpSession(db storeI) int {
+	count := 1
+	if raw, err := db.GetMeta(metaSessionCount); err == nil {
+		if n, err := strconv.Atoi(raw); err == nil {
+			count = n + 1
+		}
+	}
+	db.SetMeta(metaSessionCount, strconv.Itoa(count))
+	return count
+}
+
+func runErosion(db storeI, level string) (map[string]any, error) {
+	var memories []*model.Memory
+	var err error
+
+	switch level {
+	case "quick":
+		memories, err = db.ListByState(model.StateActive)
+	case "standard":
+		active, err1 := db.ListByState(model.StateActive)
+		dormant, err2 := db.ListByState(model.StateDormant)
+		if err1 != nil {
+			return nil, fmt.Errorf("erode list active: %w", err1)
+		}
+		if err2 != nil {
+			return nil, fmt.Errorf("erode list dormant: %w", err2)
+		}
+		memories = append(active, dormant...)
+	case "deep":
+		memories, err = db.ListAll()
+	}
+	if err != nil {
+		return nil, fmt.Errorf("erode list: %w", err)
+	}
+
+	return applyErosion(db, memories)
+}
+
+func applyErosion(db storeI, memories []*model.Memory) (map[string]any, error) {
 	cfg := decay.DefaultConfig()
 	now := timeNow()
 
@@ -443,7 +548,7 @@ func cmdErode(args []string, w io.Writer) error {
 	}
 	var pending []pendingUpdate
 
-	for _, m := range all {
+	for _, m := range memories {
 		oldState := m.State
 		oldConf := m.Confidence
 
@@ -470,7 +575,7 @@ func cmdErode(args []string, w io.Writer) error {
 			}
 			return nil
 		}); err != nil {
-			return err
+			return nil, err
 		}
 	}
 
@@ -487,11 +592,24 @@ func cmdErode(args []string, w io.Writer) error {
 		}
 	}
 
-	return writeJSON(w, map[string]any{
-		"processed":   len(all),
+	return map[string]any{
+		"processed":   len(memories),
 		"updated":     updated,
 		"transitions": transitions,
-	})
+	}, nil
+}
+
+func erodeAll(db storeI, w io.Writer) error {
+	all, err := db.ListAll()
+	if err != nil {
+		return fmt.Errorf("erode list: %w", err)
+	}
+
+	result, err := applyErosion(db, all)
+	if err != nil {
+		return err
+	}
+	return writeJSON(w, result)
 }
 
 // cmdCompact has two modes:
@@ -662,6 +780,10 @@ func cmdResolve(args []string, w io.Writer) error {
 		// Archive the old memory and deposit a new one in a single transaction.
 		m.State = model.StateArchived
 		m.UpdatedAt = now
+		hardness := m.Hardness
+		if hardness < model.HardnessMin {
+			hardness = model.HardnessDefault
+		}
 		newMem := &model.Memory{
 			ID:             newUUID(),
 			Content:        content,
@@ -673,6 +795,7 @@ func cmdResolve(args []string, w io.Writer) error {
 			LastAccessedAt: now,
 			Tags:           m.Tags,
 			Source:         "supersede:" + m.ID,
+			Hardness:       hardness,
 		}
 		if err := db.RunInTx(func() error {
 			if err := db.Update(m); err != nil {

--- a/cmd/sediment/main_test.go
+++ b/cmd/sediment/main_test.go
@@ -24,6 +24,7 @@ type mockStore struct {
 	updateFn      func(*model.Memory) error
 	deleteFn      func(string) error
 	runInTxFn     func(func() error) error
+	meta          map[string]string
 	closed        bool
 }
 
@@ -69,8 +70,24 @@ func (m *mockStore) RunInTx(fn func() error) error {
 	if m.runInTxFn != nil {
 		return m.runInTxFn(fn)
 	}
-	// Default: just run fn directly (no actual transaction in mock).
 	return fn()
+}
+func (m *mockStore) GetMeta(key string) (string, error) {
+	if m.meta == nil {
+		return "", store.ErrNotFound
+	}
+	v, ok := m.meta[key]
+	if !ok {
+		return "", store.ErrNotFound
+	}
+	return v, nil
+}
+func (m *mockStore) SetMeta(key, value string) error {
+	if m.meta == nil {
+		m.meta = make(map[string]string)
+	}
+	m.meta[key] = value
+	return nil
 }
 
 func setOpenFunc(fn func(string) (storeI, error)) func() {
@@ -378,11 +395,79 @@ func TestCmdDeposit(t *testing.T) {
 		LastAccessedAt: fixedTime,
 		Tags:           []string{"preference", "ui"},
 		Source:         "conversation-42",
+		Hardness:       model.HardnessDefault,
 	}
 	wantJSON, _ := json.Marshal(want)
 	gotJSON, _ := json.Marshal(got)
 	if string(gotJSON) != string(wantJSON) {
 		t.Errorf("deposit output\n got: %s\nwant: %s", gotJSON, wantJSON)
+	}
+}
+
+func TestCmdDepositWithHardness(t *testing.T) {
+	dir := t.TempDir()
+	dbFile := filepath.Join(dir, "deposit.db")
+
+	var initBuf bytes.Buffer
+	if err := run([]string{"init", "--db", dbFile}, &initBuf); err != nil {
+		t.Fatalf("init: %v", err)
+	}
+
+	fixedTime := time.Date(2026, 4, 17, 12, 0, 0, 0, time.UTC)
+	restoreUUID := setUUID("hardness-uuid")
+	defer restoreUUID()
+	restoreTime := setTimeNow(fixedTime)
+	defer restoreTime()
+
+	var buf bytes.Buffer
+	err := run([]string{
+		"deposit",
+		"--db", dbFile,
+		"--content", "Team uses vitest",
+		"--hardness", "9",
+	}, &buf)
+	if err != nil {
+		t.Fatalf("deposit: %v", err)
+	}
+
+	var got model.Memory
+	if err := json.Unmarshal(buf.Bytes(), &got); err != nil {
+		t.Fatalf("parse JSON: %v", err)
+	}
+	if got.Hardness != 9 {
+		t.Errorf("Hardness = %d, want 9", got.Hardness)
+	}
+}
+
+func TestCmdDepositInvalidHardness(t *testing.T) {
+	t.Parallel()
+	var buf bytes.Buffer
+	err := run([]string{
+		"deposit",
+		"--content", "test",
+		"--hardness", "15",
+	}, &buf)
+	if err == nil {
+		t.Fatal("expected error for hardness 15")
+	}
+	if !strings.Contains(err.Error(), "out of range") {
+		t.Errorf("error = %q, want 'out of range'", err)
+	}
+}
+
+func TestCmdDepositNonNumericHardness(t *testing.T) {
+	t.Parallel()
+	var buf bytes.Buffer
+	err := run([]string{
+		"deposit",
+		"--content", "test",
+		"--hardness", "abc",
+	}, &buf)
+	if err == nil {
+		t.Fatal("expected error for non-numeric hardness")
+	}
+	if !strings.Contains(err.Error(), "must be a number") {
+		t.Errorf("error = %q, want 'must be a number'", err)
 	}
 }
 
@@ -938,6 +1023,7 @@ func TestCmdErodeWithTransitions(t *testing.T) {
 		UpdatedAt:      fixedTime.Add(-200 * time.Hour),
 		LastAccessedAt: fixedTime.Add(-200 * time.Hour),
 		Tags:           []string{"fact"},
+		Hardness:       1,
 	}
 
 	// Fresh memory: accessed now, no decay.
@@ -949,6 +1035,7 @@ func TestCmdErodeWithTransitions(t *testing.T) {
 		LastAccessedAt: fixedTime,
 		UpdatedAt:      fixedTime,
 		Tags:           []string{},
+		Hardness:       5,
 	}
 
 	var updatedIDs []string
@@ -1083,6 +1170,7 @@ func TestCmdErodeDormantTransition(t *testing.T) {
 		LastAccessedAt: fixedTime.Add(-50 * time.Hour),
 		UpdatedAt:      fixedTime.Add(-50 * time.Hour),
 		Tags:           []string{},
+		Hardness:       1,
 	}
 
 	restore := setOpenFunc(func(_ string) (storeI, error) {
@@ -1112,6 +1200,292 @@ func TestCmdErodeDormantTransition(t *testing.T) {
 	first := ts[0].(map[string]any)
 	if first["new_state"] != "dormant" {
 		t.Errorf("new_state = %v, want dormant", first["new_state"])
+	}
+}
+
+func TestCmdErodeAutoQuick(t *testing.T) {
+	fixedTime := time.Date(2026, 4, 17, 12, 0, 0, 0, time.UTC)
+	restoreTime := setTimeNow(fixedTime)
+	defer restoreTime()
+
+	active := []*model.Memory{
+		{ID: "a1", Content: "fact", Confidence: 0.8, State: model.StateActive, LastAccessedAt: fixedTime, Hardness: 5, Tags: []string{}},
+	}
+
+	restore := setOpenFunc(func(_ string) (storeI, error) {
+		return &mockStore{
+			listByStateFn: func(s model.State) ([]*model.Memory, error) {
+				if s == model.StateActive {
+					return active, nil
+				}
+				return nil, nil
+			},
+		}, nil
+	})
+	defer restore()
+
+	var buf bytes.Buffer
+	if err := cmdErode([]string{"--auto"}, &buf); err != nil {
+		t.Fatalf("erode --auto: %v", err)
+	}
+
+	var result map[string]any
+	if err := json.Unmarshal(buf.Bytes(), &result); err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if result["level"] != "quick" {
+		t.Errorf("level = %v, want quick", result["level"])
+	}
+	if result["session"].(float64) != 1 {
+		t.Errorf("session = %v, want 1", result["session"])
+	}
+}
+
+func TestCmdErodeAutoStandard(t *testing.T) {
+	fixedTime := time.Date(2026, 4, 17, 12, 0, 0, 0, time.UTC)
+	restoreTime := setTimeNow(fixedTime)
+	defer restoreTime()
+
+	active := make([]*model.Memory, 100)
+	for i := range active {
+		active[i] = &model.Memory{
+			ID: fmt.Sprintf("a%d", i), Content: "fact", Confidence: 0.8,
+			State: model.StateActive, LastAccessedAt: fixedTime, Hardness: 5, Tags: []string{},
+		}
+	}
+
+	restore := setOpenFunc(func(_ string) (storeI, error) {
+		return &mockStore{
+			listByStateFn: func(s model.State) ([]*model.Memory, error) {
+				if s == model.StateActive {
+					return active, nil
+				}
+				if s == model.StateDormant {
+					return nil, nil
+				}
+				return nil, nil
+			},
+		}, nil
+	})
+	defer restore()
+
+	var buf bytes.Buffer
+	if err := cmdErode([]string{"--auto"}, &buf); err != nil {
+		t.Fatalf("erode --auto: %v", err)
+	}
+
+	var result map[string]any
+	if err := json.Unmarshal(buf.Bytes(), &result); err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if result["level"] != "standard" {
+		t.Errorf("level = %v, want standard", result["level"])
+	}
+}
+
+func TestCmdErodeAutoDeep(t *testing.T) {
+	fixedTime := time.Date(2026, 4, 17, 12, 0, 0, 0, time.UTC)
+	restoreTime := setTimeNow(fixedTime)
+	defer restoreTime()
+
+	active := make([]*model.Memory, 100)
+	for i := range active {
+		active[i] = &model.Memory{
+			ID: fmt.Sprintf("a%d", i), Content: "fact", Confidence: 0.8,
+			State: model.StateActive, LastAccessedAt: fixedTime, Hardness: 5, Tags: []string{},
+		}
+	}
+
+	ms := &mockStore{
+		meta: map[string]string{metaSessionCount: "9"},
+		listByStateFn: func(s model.State) ([]*model.Memory, error) {
+			if s == model.StateActive {
+				return active, nil
+			}
+			return nil, nil
+		},
+		listAllFn: func() ([]*model.Memory, error) {
+			return active, nil
+		},
+	}
+
+	restore := setOpenFunc(func(_ string) (storeI, error) {
+		return ms, nil
+	})
+	defer restore()
+
+	var buf bytes.Buffer
+	if err := cmdErode([]string{"--auto"}, &buf); err != nil {
+		t.Fatalf("erode --auto: %v", err)
+	}
+
+	var result map[string]any
+	if err := json.Unmarshal(buf.Bytes(), &result); err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if result["level"] != "deep" {
+		t.Errorf("level = %v, want deep", result["level"])
+	}
+	if result["session"].(float64) != 10 {
+		t.Errorf("session = %v, want 10", result["session"])
+	}
+}
+
+func TestBumpSession(t *testing.T) {
+	ms := &mockStore{}
+
+	n1 := bumpSession(ms)
+	if n1 != 1 {
+		t.Errorf("first bump = %d, want 1", n1)
+	}
+
+	n2 := bumpSession(ms)
+	if n2 != 2 {
+		t.Errorf("second bump = %d, want 2", n2)
+	}
+}
+
+func TestCmdErodeAutoListError(t *testing.T) {
+	restore := setOpenFunc(func(_ string) (storeI, error) {
+		return &mockStore{
+			listByStateFn: func(s model.State) ([]*model.Memory, error) {
+				return nil, fmt.Errorf("list failed")
+			},
+		}, nil
+	})
+	defer restore()
+
+	var buf bytes.Buffer
+	err := cmdErode([]string{"--auto"}, &buf)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "erode list active") {
+		t.Errorf("error = %q, want 'erode list active'", err)
+	}
+}
+
+func TestRunErosionStandardErrors(t *testing.T) {
+	calls := 0
+	ms := &mockStore{
+		listByStateFn: func(s model.State) ([]*model.Memory, error) {
+			calls++
+			if calls == 1 {
+				return nil, nil
+			}
+			return nil, fmt.Errorf("dormant fail")
+		},
+	}
+
+	_, err := runErosion(ms, "standard")
+	if err == nil {
+		t.Fatal("expected dormant error")
+	}
+	if !strings.Contains(err.Error(), "erode list dormant") {
+		t.Errorf("error = %q, want 'erode list dormant'", err)
+	}
+}
+
+func TestRunErosionStandardActiveError(t *testing.T) {
+	ms := &mockStore{
+		listByStateFn: func(s model.State) ([]*model.Memory, error) {
+			if s == model.StateActive {
+				return nil, fmt.Errorf("active fail")
+			}
+			return nil, nil
+		},
+	}
+
+	_, err := runErosion(ms, "standard")
+	if err == nil {
+		t.Fatal("expected active error")
+	}
+	if !strings.Contains(err.Error(), "erode list active") {
+		t.Errorf("error = %q, want 'erode list active'", err)
+	}
+}
+
+func TestRunErosionQuickError(t *testing.T) {
+	ms := &mockStore{
+		listByStateFn: func(s model.State) ([]*model.Memory, error) {
+			return nil, fmt.Errorf("quick fail")
+		},
+	}
+
+	_, err := runErosion(ms, "quick")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestRunErosionDeepError(t *testing.T) {
+	ms := &mockStore{
+		listAllFn: func() ([]*model.Memory, error) {
+			return nil, fmt.Errorf("deep fail")
+		},
+	}
+
+	_, err := runErosion(ms, "deep")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestAutoErodeRunErosionError(t *testing.T) {
+	fixedTime := time.Date(2026, 4, 17, 12, 0, 0, 0, time.UTC)
+	restoreTime := setTimeNow(fixedTime)
+	defer restoreTime()
+
+	calls := 0
+	ms := &mockStore{
+		listByStateFn: func(s model.State) ([]*model.Memory, error) {
+			calls++
+			if calls == 1 {
+				return nil, nil
+			}
+			return nil, fmt.Errorf("quick fail")
+		},
+	}
+
+	restore := setOpenFunc(func(_ string) (storeI, error) {
+		return ms, nil
+	})
+	defer restore()
+
+	var buf bytes.Buffer
+	err := cmdErode([]string{"--auto"}, &buf)
+	if err == nil {
+		t.Fatal("expected error from runErosion failure")
+	}
+}
+
+func TestAutoErodeSetMetaError(t *testing.T) {
+	fixedTime := time.Date(2026, 4, 17, 12, 0, 0, 0, time.UTC)
+	restoreTime := setTimeNow(fixedTime)
+	defer restoreTime()
+
+	ms := &mockStore{
+		listByStateFn: func(s model.State) ([]*model.Memory, error) {
+			return nil, nil
+		},
+	}
+
+	restore := setOpenFunc(func(_ string) (storeI, error) {
+		return ms, nil
+	})
+	defer restore()
+
+	var buf bytes.Buffer
+	if err := cmdErode([]string{"--auto"}, &buf); err != nil {
+		t.Fatalf("erode --auto: %v", err)
+	}
+
+	var result map[string]any
+	if err := json.Unmarshal(buf.Bytes(), &result); err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if result["level"] != "quick" {
+		t.Errorf("level = %v, want quick", result["level"])
 	}
 }
 

--- a/internal/decay/decay.go
+++ b/internal/decay/decay.go
@@ -42,13 +42,23 @@ func DefaultConfig() Config {
 	}
 }
 
+// EffectiveLambda adjusts the base decay rate by hardness.
+// Harder memories decay more slowly: lambda_eff = lambda / hardness.
+func EffectiveLambda(lambda float64, h model.Hardness) float64 {
+	if h < model.HardnessMin {
+		h = model.HardnessDefault
+	}
+	return lambda / float64(h)
+}
+
 // CurrentConfidence computes the decayed confidence at the given time.
 func CurrentConfidence(m *model.Memory, now time.Time, lambda float64) float64 {
 	hours := now.Sub(m.LastAccessedAt).Hours()
 	if hours < 0 {
 		hours = 0
 	}
-	decayed := m.Confidence * math.Exp(-lambda*hours)
+	effectiveLambda := EffectiveLambda(lambda, m.Hardness)
+	decayed := m.Confidence * math.Exp(-effectiveLambda*hours)
 	return clamp(decayed, 0, 1)
 }
 

--- a/internal/decay/decay_test.go
+++ b/internal/decay/decay_test.go
@@ -11,10 +11,36 @@ import (
 
 var baseCfg = decay.DefaultConfig()
 
+func TestEffectiveLambda(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		lambda   float64
+		hardness model.Hardness
+		want     float64
+	}{
+		{"hardness 1 (talc)", 0.01, 1, 0.01},
+		{"hardness 5 (default)", 0.01, 5, 0.002},
+		{"hardness 10 (diamond)", 0.01, 10, 0.001},
+		{"zero hardness uses default", 0.01, 0, 0.002},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := decay.EffectiveLambda(tt.lambda, tt.hardness)
+			if math.Abs(got-tt.want) > 1e-9 {
+				t.Errorf("EffectiveLambda(%v, %d) = %v, want %v", tt.lambda, tt.hardness, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestCurrentConfidence_NoDecay(t *testing.T) {
 	t.Parallel()
 	now := time.Now()
-	m := &model.Memory{Confidence: 0.8, LastAccessedAt: now}
+	m := &model.Memory{Confidence: 0.8, LastAccessedAt: now, Hardness: 5}
 
 	got := decay.CurrentConfidence(m, now, baseCfg.Lambda)
 	if math.Abs(got-0.8) > 1e-9 {
@@ -25,9 +51,10 @@ func TestCurrentConfidence_NoDecay(t *testing.T) {
 func TestCurrentConfidence_AfterHours(t *testing.T) {
 	t.Parallel()
 	now := time.Now()
-	m := &model.Memory{Confidence: 1.0, LastAccessedAt: now.Add(-24 * time.Hour)}
+	m := &model.Memory{Confidence: 1.0, LastAccessedAt: now.Add(-24 * time.Hour), Hardness: 1}
 
 	got := decay.CurrentConfidence(m, now, baseCfg.Lambda)
+	// hardness=1: lambda_eff = 0.01/1 = 0.01
 	// 1.0 * e^(-0.01 * 24) = e^(-0.24) ≈ 0.7866
 	want := math.Exp(-0.24)
 	if math.Abs(got-want) > 1e-4 {
@@ -38,7 +65,7 @@ func TestCurrentConfidence_AfterHours(t *testing.T) {
 func TestCurrentConfidence_FutureTime(t *testing.T) {
 	t.Parallel()
 	now := time.Now()
-	m := &model.Memory{Confidence: 0.5, LastAccessedAt: now.Add(1 * time.Hour)}
+	m := &model.Memory{Confidence: 0.5, LastAccessedAt: now.Add(1 * time.Hour), Hardness: 5}
 
 	// Future access time should not increase confidence (hours clamped to 0).
 	got := decay.CurrentConfidence(m, now, baseCfg.Lambda)
@@ -50,7 +77,7 @@ func TestCurrentConfidence_FutureTime(t *testing.T) {
 func TestCurrentConfidence_VeryOld(t *testing.T) {
 	t.Parallel()
 	now := time.Now()
-	m := &model.Memory{Confidence: 1.0, LastAccessedAt: now.Add(-10000 * time.Hour)}
+	m := &model.Memory{Confidence: 1.0, LastAccessedAt: now.Add(-10000 * time.Hour), Hardness: 5}
 
 	got := decay.CurrentConfidence(m, now, baseCfg.Lambda)
 	if got < 0 {
@@ -69,6 +96,7 @@ func TestReinforce(t *testing.T) {
 		AccessCount:    2,
 		LastAccessedAt: now.Add(-10 * time.Hour),
 		UpdatedAt:      now.Add(-10 * time.Hour),
+		Hardness:       1,
 	}
 
 	decay.Reinforce(m, now, baseCfg)
@@ -96,6 +124,7 @@ func TestReinforce_CapsAt1(t *testing.T) {
 	m := &model.Memory{
 		Confidence:     0.95,
 		LastAccessedAt: now,
+		Hardness:       5,
 	}
 
 	decay.Reinforce(m, now, baseCfg)
@@ -153,11 +182,27 @@ func TestDefaultConfig(t *testing.T) {
 	}
 }
 
+func TestCurrentConfidence_HardnessSlowsDecay(t *testing.T) {
+	t.Parallel()
+	now := time.Now()
+	past := now.Add(-48 * time.Hour)
+
+	soft := &model.Memory{Confidence: 1.0, LastAccessedAt: past, Hardness: 1}
+	hard := &model.Memory{Confidence: 1.0, LastAccessedAt: past, Hardness: 10}
+
+	softConf := decay.CurrentConfidence(soft, now, baseCfg.Lambda)
+	hardConf := decay.CurrentConfidence(hard, now, baseCfg.Lambda)
+
+	if hardConf <= softConf {
+		t.Errorf("hard memory (%v) should decay slower than soft (%v)", hardConf, softConf)
+	}
+}
+
 func TestCurrentConfidence_NegativeResult(t *testing.T) {
 	t.Parallel()
 	now := time.Now()
 	// Negative confidence should be clamped to 0.
-	m := &model.Memory{Confidence: -0.5, LastAccessedAt: now}
+	m := &model.Memory{Confidence: -0.5, LastAccessedAt: now, Hardness: 5}
 	got := decay.CurrentConfidence(m, now, 0.01)
 	if got != 0 {
 		t.Errorf("CurrentConfidence = %v, want 0 (clamped)", got)
@@ -170,6 +215,7 @@ func TestReinforce_HighBoostClamped(t *testing.T) {
 	m := &model.Memory{
 		Confidence:     0.99,
 		LastAccessedAt: now,
+		Hardness:       5,
 	}
 	// Use a very high boost to ensure clamping at 1.0.
 	cfg := decay.Config{

--- a/internal/model/memory.go
+++ b/internal/model/memory.go
@@ -5,7 +5,35 @@
 // excavated when needed.
 package model
 
-import "time"
+import (
+	"fmt"
+	"time"
+)
+
+// Hardness represents durability on the Mohs scale (1–10).
+// Softer memories erode faster; harder memories resist decay.
+//
+//	1–3  Talc–Calcite:    situational, one-off (high decay rate)
+//	4–6  Fluorite–Feldspar: decisions, preferences (moderate decay)
+//	7–10 Quartz–Diamond:   conventions, patterns  (low decay rate)
+type Hardness int
+
+const (
+	HardnessMin     Hardness = 1
+	HardnessDefault Hardness = 5
+	HardnessMax     Hardness = 10
+)
+
+func (h Hardness) Valid() bool {
+	return h >= HardnessMin && h <= HardnessMax
+}
+
+func (h Hardness) Validate() error {
+	if !h.Valid() {
+		return fmt.Errorf("hardness %d out of range [%d, %d]", h, HardnessMin, HardnessMax)
+	}
+	return nil
+}
 
 // State represents the lifecycle state of a memory.
 type State string
@@ -41,6 +69,8 @@ type Memory struct {
 	Tags []string `json:"tags"`
 	// Source records where the memory came from (optional).
 	Source string `json:"source,omitempty"`
+	// Hardness is the durability rating on the Mohs scale (1–10).
+	Hardness Hardness `json:"hardness"`
 }
 
 // ValidStates is the set of recognised lifecycle states.

--- a/internal/model/memory_test.go
+++ b/internal/model/memory_test.go
@@ -7,6 +7,43 @@ import (
 	"github.com/jacobjnilsson/sediment/internal/model"
 )
 
+func TestHardness_Valid(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		h    model.Hardness
+		want bool
+	}{
+		{"zero is invalid", 0, false},
+		{"min is valid", 1, true},
+		{"mid is valid", 5, true},
+		{"max is valid", 10, true},
+		{"above max is invalid", 11, false},
+		{"negative is invalid", -1, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := tt.h.Valid(); got != tt.want {
+				t.Errorf("Hardness(%d).Valid() = %v, want %v", tt.h, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestHardness_Validate(t *testing.T) {
+	t.Parallel()
+
+	if err := model.HardnessDefault.Validate(); err != nil {
+		t.Errorf("HardnessDefault.Validate() = %v, want nil", err)
+	}
+	if err := model.Hardness(0).Validate(); err == nil {
+		t.Error("Hardness(0).Validate() = nil, want error")
+	}
+}
+
 func TestIsRetrievable(t *testing.T) {
 	t.Parallel()
 

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -59,14 +59,45 @@ func (d *DB) Migrate() error {
 		updated_at      TEXT NOT NULL,
 		last_accessed_at TEXT NOT NULL,
 		tags            TEXT NOT NULL DEFAULT '[]',
-		source          TEXT NOT NULL DEFAULT ''
+		source          TEXT NOT NULL DEFAULT '',
+		hardness        INTEGER NOT NULL DEFAULT 5
 	);
 	CREATE INDEX IF NOT EXISTS idx_memories_state ON memories(state);
 	CREATE INDEX IF NOT EXISTS idx_memories_confidence ON memories(confidence);
+	CREATE TABLE IF NOT EXISTS meta (
+		key   TEXT PRIMARY KEY,
+		value TEXT NOT NULL
+	);
 	`
 	_, err := d.exec.Exec(schema)
 	if err != nil {
 		return fmt.Errorf("migrate: %w", err)
+	}
+
+	d.exec.Exec(`ALTER TABLE memories ADD COLUMN hardness INTEGER NOT NULL DEFAULT 5`)
+
+	return nil
+}
+
+func (d *DB) GetMeta(key string) (string, error) {
+	var value string
+	err := d.exec.QueryRow(`SELECT value FROM meta WHERE key = ?`, key).Scan(&value)
+	if errors.Is(err, sql.ErrNoRows) {
+		return "", ErrNotFound
+	}
+	if err != nil {
+		return "", fmt.Errorf("get meta %q: %w", key, err)
+	}
+	return value, nil
+}
+
+func (d *DB) SetMeta(key, value string) error {
+	_, err := d.exec.Exec(
+		`INSERT INTO meta (key, value) VALUES (?, ?) ON CONFLICT(key) DO UPDATE SET value = excluded.value`,
+		key, value,
+	)
+	if err != nil {
+		return fmt.Errorf("set meta %q: %w", key, err)
 	}
 	return nil
 }
@@ -83,13 +114,13 @@ func MarshalTags(tags []string) string {
 // Insert stores a new memory.
 func (d *DB) Insert(m *model.Memory) error {
 	_, err := d.exec.Exec(
-		`INSERT INTO memories (id, content, confidence, state, access_count, created_at, updated_at, last_accessed_at, tags, source)
-		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		`INSERT INTO memories (id, content, confidence, state, access_count, created_at, updated_at, last_accessed_at, tags, source, hardness)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		m.ID, m.Content, m.Confidence, string(m.State), m.AccessCount,
 		m.CreatedAt.Format(time.RFC3339Nano),
 		m.UpdatedAt.Format(time.RFC3339Nano),
 		m.LastAccessedAt.Format(time.RFC3339Nano),
-		MarshalTags(m.Tags), m.Source,
+		MarshalTags(m.Tags), m.Source, int(m.Hardness),
 	)
 	if err != nil {
 		return fmt.Errorf("insert memory: %w", err)
@@ -100,7 +131,7 @@ func (d *DB) Insert(m *model.Memory) error {
 // Get retrieves a single memory by ID.
 func (d *DB) Get(id string) (*model.Memory, error) {
 	row := d.exec.QueryRow(
-		`SELECT id, content, confidence, state, access_count, created_at, updated_at, last_accessed_at, tags, source
+		`SELECT id, content, confidence, state, access_count, created_at, updated_at, last_accessed_at, tags, source, hardness
 		 FROM memories WHERE id = ?`, id,
 	)
 	return scanMemory(row)
@@ -109,12 +140,14 @@ func (d *DB) Get(id string) (*model.Memory, error) {
 // Update replaces a memory's mutable fields.
 func (d *DB) Update(m *model.Memory) error {
 	res, err := d.exec.Exec(
-		`UPDATE memories SET content=?, confidence=?, state=?, access_count=?, updated_at=?, last_accessed_at=?, tags=?, source=?
-		 WHERE id=?`,
+		`UPDATE memories
+		 SET content = ?, confidence = ?, state = ?, access_count = ?,
+		     updated_at = ?, last_accessed_at = ?, tags = ?, source = ?, hardness = ?
+		 WHERE id = ?`,
 		m.Content, m.Confidence, string(m.State), m.AccessCount,
 		m.UpdatedAt.Format(time.RFC3339Nano),
 		m.LastAccessedAt.Format(time.RFC3339Nano),
-		MarshalTags(m.Tags), m.Source, m.ID,
+		MarshalTags(m.Tags), m.Source, int(m.Hardness), m.ID,
 	)
 	if err != nil {
 		return fmt.Errorf("update memory: %w", err)
@@ -142,7 +175,7 @@ func (d *DB) Delete(id string) error {
 // ListByState returns all memories in a given state, ordered by confidence descending.
 func (d *DB) ListByState(state model.State) ([]*model.Memory, error) {
 	rows, err := d.exec.Query(
-		`SELECT id, content, confidence, state, access_count, created_at, updated_at, last_accessed_at, tags, source
+		`SELECT id, content, confidence, state, access_count, created_at, updated_at, last_accessed_at, tags, source, hardness
 		 FROM memories WHERE state = ? ORDER BY confidence DESC`, string(state),
 	)
 	if err != nil {
@@ -155,7 +188,7 @@ func (d *DB) ListByState(state model.State) ([]*model.Memory, error) {
 // ListAll returns all memories ordered by confidence descending.
 func (d *DB) ListAll() ([]*model.Memory, error) {
 	rows, err := d.exec.Query(
-		`SELECT id, content, confidence, state, access_count, created_at, updated_at, last_accessed_at, tags, source
+		`SELECT id, content, confidence, state, access_count, created_at, updated_at, last_accessed_at, tags, source, hardness
 		 FROM memories ORDER BY confidence DESC`,
 	)
 	if err != nil {
@@ -210,9 +243,10 @@ func scanMemory(s scanner) (*model.Memory, error) {
 		createdAt, updatedAt, lastAccessedAt string
 		tagsJSON                             string
 	)
+	var hardness int
 	err := s.Scan(
 		&m.ID, &m.Content, &m.Confidence, &state, &m.AccessCount,
-		&createdAt, &updatedAt, &lastAccessedAt, &tagsJSON, &m.Source,
+		&createdAt, &updatedAt, &lastAccessedAt, &tagsJSON, &m.Source, &hardness,
 	)
 	if errors.Is(err, sql.ErrNoRows) {
 		return nil, ErrNotFound
@@ -227,6 +261,7 @@ func scanMemory(s scanner) (*model.Memory, error) {
 	if err := json.Unmarshal([]byte(tagsJSON), &m.Tags); err != nil {
 		return nil, fmt.Errorf("unmarshal tags: %w", err)
 	}
+	m.Hardness = model.Hardness(hardness)
 	return &m, nil
 }
 

--- a/internal/store/store_internal_test.go
+++ b/internal/store/store_internal_test.go
@@ -3,6 +3,7 @@ package store
 import (
 	"database/sql"
 	"fmt"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -22,7 +23,8 @@ func testDB(t *testing.T) *sql.DB {
 	CREATE TABLE memories (
 		id TEXT PRIMARY KEY, content TEXT, confidence REAL,
 		state TEXT, access_count INTEGER, created_at TEXT,
-		updated_at TEXT, last_accessed_at TEXT, tags TEXT, source TEXT
+		updated_at TEXT, last_accessed_at TEXT, tags TEXT, source TEXT,
+		hardness INTEGER NOT NULL DEFAULT 5
 	)`)
 	if err != nil {
 		t.Fatalf("create table: %v", err)
@@ -37,8 +39,8 @@ func TestScanMemoryUnmarshalTagsError(t *testing.T) {
 
 	now := time.Now().Format(time.RFC3339Nano)
 	_, err := db.Exec(
-		`INSERT INTO memories VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-		"id-1", "content", 0.9, "active", 0, now, now, now, "NOT-JSON", "",
+		`INSERT INTO memories VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		"id-1", "content", 0.9, "active", 0, now, now, now, "NOT-JSON", "", 5,
 	)
 	if err != nil {
 		t.Fatalf("insert: %v", err)
@@ -61,8 +63,8 @@ func TestScanMemoryScanError(t *testing.T) {
 	// Wrong column count triggers a scan error on an existing row.
 	now := time.Now().Format(time.RFC3339Nano)
 	_, err := db.Exec(
-		`INSERT INTO memories VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-		"id-scan", "content", 0.9, "active", 0, now, now, now, "[]", "",
+		`INSERT INTO memories VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		"id-scan", "content", 0.9, "active", 0, now, now, now, "[]", "", 5,
 	)
 	if err != nil {
 		t.Fatalf("insert: %v", err)
@@ -84,8 +86,8 @@ func TestCollectMemoriesScanError(t *testing.T) {
 
 	now := time.Now().Format(time.RFC3339Nano)
 	_, err := db.Exec(
-		`INSERT INTO memories VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-		"id-2", "content", 0.9, "active", 0, now, now, now, "BAD-JSON", "",
+		`INSERT INTO memories VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		"id-2", "content", 0.9, "active", 0, now, now, now, "BAD-JSON", "", 5,
 	)
 	if err != nil {
 		t.Fatalf("insert: %v", err)
@@ -111,8 +113,8 @@ func TestCollectMemoriesRowsErr(t *testing.T) {
 
 	now := time.Now().Format(time.RFC3339Nano)
 	_, err := db.Exec(
-		`INSERT INTO memories VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-		"id-ok", "content", 0.9, "active", 0, now, now, now, `["tag"]`, "",
+		`INSERT INTO memories VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		"id-ok", "content", 0.9, "active", 0, now, now, now, `["tag"]`, "", 5,
 	)
 	if err != nil {
 		t.Fatalf("insert: %v", err)
@@ -378,5 +380,53 @@ func TestRunInTxMultipleOps(t *testing.T) {
 	_, err = d.Get("tx-m1")
 	if err != ErrNotFound {
 		t.Errorf("expected ErrNotFound for m1, got %v", err)
+	}
+}
+
+func TestMigrateMetaSchemaError(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "metaerr.db")
+
+	rawDB, err := os.Create(dbPath)
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	rawDB.WriteString("not a database")
+	rawDB.Close()
+
+	conn, err := sql.Open("sqlite3", dbPath)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer conn.Close()
+
+	d := &DB{exec: conn, conn: conn}
+	err = d.Migrate()
+	if err == nil {
+		t.Fatal("expected error on corrupt db")
+	}
+	if !strings.Contains(err.Error(), "migrate") {
+		t.Errorf("error = %q, want mention of migrate", err)
+	}
+}
+
+func TestMigrateAlterTableDuplicateColumn(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "dup.db")
+
+	conn, err := sql.Open("sqlite3", dbPath)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer conn.Close()
+
+	d := &DB{exec: conn, conn: conn}
+	if err := d.Migrate(); err != nil {
+		t.Fatalf("first migrate: %v", err)
+	}
+	if err := d.Migrate(); err != nil {
+		t.Fatalf("second migrate (duplicate column should be ignored): %v", err)
 	}
 }

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -467,6 +467,102 @@ func TestMigrateOnClosedDB(t *testing.T) {
 	}
 }
 
+func TestMetaGetSetRoundTrip(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	db, err := store.Open(filepath.Join(dir, "meta.db"))
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer db.Close()
+	if err := db.Migrate(); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+
+	_, err = db.GetMeta("missing")
+	if !errors.Is(err, store.ErrNotFound) {
+		t.Errorf("GetMeta(missing) = %v, want ErrNotFound", err)
+	}
+
+	if err := db.SetMeta("key1", "value1"); err != nil {
+		t.Fatalf("SetMeta: %v", err)
+	}
+	got, err := db.GetMeta("key1")
+	if err != nil {
+		t.Fatalf("GetMeta: %v", err)
+	}
+	if got != "value1" {
+		t.Errorf("GetMeta = %q, want value1", got)
+	}
+
+	if err := db.SetMeta("key1", "updated"); err != nil {
+		t.Fatalf("SetMeta upsert: %v", err)
+	}
+	got, err = db.GetMeta("key1")
+	if err != nil {
+		t.Fatalf("GetMeta: %v", err)
+	}
+	if got != "updated" {
+		t.Errorf("GetMeta after upsert = %q, want updated", got)
+	}
+}
+
+func TestMigrateIdempotent(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "meta-err.db")
+	db, err := store.Open(dbPath)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	if err := db.Migrate(); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	if err := db.Migrate(); err != nil {
+		t.Fatalf("re-migrate should be idempotent: %v", err)
+	}
+	db.Close()
+}
+
+func TestSetMetaError(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	db, err := store.Open(filepath.Join(dir, "seterr.db"))
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	if err := db.Migrate(); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	db.Close()
+
+	err = db.SetMeta("key", "val")
+	if err == nil {
+		t.Fatal("expected error on closed db")
+	}
+}
+
+func TestGetMetaError(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	db, err := store.Open(filepath.Join(dir, "geterr.db"))
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	if err := db.Migrate(); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	db.Close()
+
+	_, err = db.GetMeta("key")
+	if err == nil {
+		t.Fatal("expected error on closed db")
+	}
+	if errors.Is(err, store.ErrNotFound) {
+		t.Error("should be a real error, not ErrNotFound")
+	}
+}
+
 func TestMarshalTags(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

Memories now carry durability (Mohs hardness scale 1-10) that directly modulates decay rate — diamond-hard memories persist while talc-soft ones fade quickly. Erosion runs automatically on session connect with tiered levels (quick/standard/deep) based on session count and memory accumulation.

An opencode plugin handles the full lifecycle without manual intervention: recalls memories on connect, injects them into compaction context, prompts the agent to deposit new learnings via `chat.message` hook, and exposes `sediment_deposit`/`sediment_recall` as tools.

Also fixes the pre-commit hook where `grep` returning non-zero on empty output silently aborted under `set -e`.

## Changes

- `model.Hardness` type (Mohs 1-10) with validation
- Decay rate: `lambda_eff = lambda / hardness`
- `--hardness` flag on `deposit`, `--auto` flag on `erode`
- Meta table + session counting for auto-erosion triggers
- `.opencode/plugins/sediment.ts` with `chat.message`, compaction, deposit/recall tools
- Updated `SKILL.md` documenting automatic vs manual workflows
- Pre-commit hook fix (`|| true` on coverage grep pipeline)