### PR TITLE
Add release pipeline with semantic versioning

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,68 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-latest
+            goos: linux
+            goarch: amd64
+          - os: ubuntu-24.04-arm
+            goos: linux
+            goarch: arm64
+          - os: macos-latest
+            goos: darwin
+            goarch: arm64
+          - os: macos-13
+            goos: darwin
+            goarch: amd64
+    runs-on: ${{ matrix.os }}
+    env:
+      CGO_ENABLED: "1"
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Build
+        run: |
+          go build -ldflags "-s -w -X main.version=${GITHUB_REF_NAME#v}" -o sediment ./cmd/sediment
+          tar -czf "sediment_${GITHUB_REF_NAME#v}_${{ matrix.goos }}_${{ matrix.goarch }}.tar.gz" sediment
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: "sediment_${{ matrix.goos }}_${{ matrix.goarch }}"
+          path: "*.tar.gz"
+
+  publish:
+    needs: release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/download-artifact@v4
+        with:
+          path: dist
+          merge-multiple: true
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: dist/*.tar.gz
+          generate_release_notes: true

--- a/cmd/sediment/main.go
+++ b/cmd/sediment/main.go
@@ -255,6 +255,8 @@ var userHomeDir = os.UserHomeDir
 // writeFile wraps os.WriteFile. Overridable for tests.
 var writeFile = os.WriteFile
 
+var version = "dev"
+
 func main() {
 	if err := run(os.Args[1:], os.Stdout); err != nil {
 		fmt.Fprintf(os.Stderr, "error: %v\n", err)
@@ -289,6 +291,11 @@ func run(args []string, w io.Writer) error {
 
 	if cmd == "--help" || cmd == "-h" {
 		fmt.Fprintln(w, globalUsage)
+		return nil
+	}
+
+	if cmd == "--version" {
+		fmt.Fprintln(w, version)
 		return nil
 	}
 

--- a/cmd/sediment/main_test.go
+++ b/cmd/sediment/main_test.go
@@ -164,6 +164,18 @@ func TestRunHelp(t *testing.T) {
 	}
 }
 
+func TestRunVersion(t *testing.T) {
+	t.Parallel()
+	var buf bytes.Buffer
+	err := run([]string{"--version"}, &buf)
+	if err != nil {
+		t.Fatalf("run(--version): %v", err)
+	}
+	if !strings.Contains(buf.String(), version) {
+		t.Errorf("run(--version) = %q, want version %q", buf.String(), version)
+	}
+}
+
 func TestRunCommandHelp(t *testing.T) {
 	t.Parallel()
 	cmds := []string{"init", "status", "deposit", "strata", "excavate", "erode", "compact", "resolve", "setup"}


### PR DESCRIPTION
No way to distribute pre-built binaries or know which version a user runs.
This adds GoReleaser config, a tag-triggered GitHub Actions workflow for
publishing releases, and a `--version` flag injected via ldflags at build time.

To release: `git tag v0.1.0 && git push --tags`

Closes #9