### PR TITLE
Add versioned upgrade system for breaking changes

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -16,7 +16,7 @@ go vet ./...
 echo "==> tests + coverage"
 go test -race -coverprofile=coverage.out -covermode=atomic ./...
 
-UNCOVERED=$(go tool cover -func=coverage.out | grep -v '100.0%' | grep -v '^total:' | grep -v '\.go:[0-9]*:	main	' || true)
+UNCOVERED=$(go tool cover -func=coverage.out | grep -v '100.0%' | grep -v '^total:' | grep -v '\.go:[0-9]*:.*	main	' || true)
 if [ -n "$UNCOVERED" ]; then
     echo ""
     echo "FAIL: functions not at 100% coverage:"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
 
       - name: Enforce 100% coverage
         run: |
-          UNCOVERED=$(go tool cover -func=coverage.out | grep -v '100.0%' | grep -v '^total:' | grep -v '\.go:[0-9]*:	main	' || true)
+          UNCOVERED=$(go tool cover -func=coverage.out | grep -v '100.0%' | grep -v '^total:' | grep -v '\.go:[0-9]*:.*	main	' || true)
           if [ -n "$UNCOVERED" ]; then
             echo "Functions not at 100% coverage:"
             echo "$UNCOVERED"

--- a/cmd/sediment/main.go
+++ b/cmd/sediment/main.go
@@ -220,7 +220,7 @@ type erodeTransition struct {
 
 // storeI is the subset of store.DB that commands need.
 type storeI interface {
-	Migrate() error
+	Migrate(dataDir string) error
 	ListAll() ([]*model.Memory, error)
 	ListByState(state model.State) ([]*model.Memory, error)
 	Get(id string) (*model.Memory, error)
@@ -353,9 +353,10 @@ func openAndMigrate(args []string) (db storeI, absPath string, err error) {
 	}
 	db, err = openFunc(absPath)
 	if err != nil {
-		return nil, "", fmt.Errorf("open database: %w", err)
+		return nil, "", err
 	}
-	if err = db.Migrate(); err != nil {
+	dataDir := filepath.Dir(absPath)
+	if err = db.Migrate(dataDir); err != nil {
 		db.Close()
 		return nil, "", fmt.Errorf("migrate: %w", err)
 	}

--- a/cmd/sediment/main_test.go
+++ b/cmd/sediment/main_test.go
@@ -28,8 +28,8 @@ type mockStore struct {
 	closed        bool
 }
 
-func (m *mockStore) Migrate() error { return m.migrateErr }
-func (m *mockStore) Close() error   { m.closed = true; return nil }
+func (m *mockStore) Migrate(_ string) error { return m.migrateErr }
+func (m *mockStore) Close() error           { m.closed = true; return nil }
 func (m *mockStore) ListAll() ([]*model.Memory, error) {
 	if m.listAllFn != nil {
 		return m.listAllFn()
@@ -753,8 +753,8 @@ func TestOpenAndMigrateOpenError(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected open error")
 	}
-	if !strings.Contains(err.Error(), "open database") {
-		t.Errorf("error = %q, want 'open database'", err)
+	if !strings.Contains(err.Error(), "cannot open") {
+		t.Errorf("error = %q, want 'cannot open'", err)
 	}
 }
 

--- a/internal/migrate/migrate.go
+++ b/internal/migrate/migrate.go
@@ -1,0 +1,77 @@
+// Package migrate runs versioned upgrades on startup.
+//
+// Each migration is a Go function that receives a context with access to the
+// database and data directory. Migrations run forward-only, sequentially from
+// the current schema version to the latest.
+package migrate
+
+import (
+	"database/sql"
+	"fmt"
+	"strconv"
+)
+
+// Context is passed to each migration function.
+type Context struct {
+	DB      *sql.DB
+	DataDir string
+}
+
+// Migration describes a single versioned upgrade step.
+type Migration struct {
+	Version     int
+	Description string
+	Up          func(ctx Context) error
+}
+
+const metaKey = "schema_version"
+
+// Run executes all pending migrations in order. It bootstraps the meta table
+// if it does not exist, reads the current schema version, and applies each
+// migration whose version exceeds the current one.
+func Run(db *sql.DB, dataDir string, migrations []Migration) error {
+	if _, err := db.Exec(`CREATE TABLE IF NOT EXISTS meta (key TEXT PRIMARY KEY, value TEXT NOT NULL)`); err != nil {
+		return fmt.Errorf("migrate: bootstrap meta: %w", err)
+	}
+
+	current, err := currentVersion(db)
+	if err != nil {
+		return fmt.Errorf("migrate: read version: %w", err)
+	}
+
+	ctx := Context{DB: db, DataDir: dataDir}
+
+	for _, m := range migrations {
+		if m.Version <= current {
+			continue
+		}
+		if err := m.Up(ctx); err != nil {
+			return fmt.Errorf("migrate: v%d (%s): %w", m.Version, m.Description, err)
+		}
+		if err := setVersion(db, m.Version); err != nil {
+			return fmt.Errorf("migrate: set version %d: %w", m.Version, err)
+		}
+	}
+
+	return nil
+}
+
+func currentVersion(db *sql.DB) (int, error) {
+	var raw string
+	err := db.QueryRow(`SELECT value FROM meta WHERE key = ?`, metaKey).Scan(&raw)
+	if err == sql.ErrNoRows {
+		return 0, nil
+	}
+	if err != nil {
+		return 0, err
+	}
+	return strconv.Atoi(raw)
+}
+
+func setVersion(db *sql.DB, v int) error {
+	_, err := db.Exec(
+		`INSERT INTO meta (key, value) VALUES (?, ?) ON CONFLICT(key) DO UPDATE SET value = excluded.value`,
+		metaKey, strconv.Itoa(v),
+	)
+	return err
+}

--- a/internal/migrate/migrate.go
+++ b/internal/migrate/migrate.go
@@ -8,6 +8,7 @@ package migrate
 import (
 	"database/sql"
 	"fmt"
+	"slices"
 	"strconv"
 )
 
@@ -26,10 +27,16 @@ type Migration struct {
 
 const metaKey = "schema_version"
 
-// Run executes all pending migrations in order. It bootstraps the meta table
-// if it does not exist, reads the current schema version, and applies each
-// migration whose version exceeds the current one.
+// Run executes all pending migrations in order. It sorts migrations by version,
+// bootstraps the meta table if it does not exist, reads the current schema
+// version, and applies each migration whose version exceeds the current one.
 func Run(db *sql.DB, dataDir string, migrations []Migration) error {
+	sorted := make([]Migration, len(migrations))
+	copy(sorted, migrations)
+	slices.SortFunc(sorted, func(a, b Migration) int {
+		return a.Version - b.Version
+	})
+
 	if _, err := db.Exec(`CREATE TABLE IF NOT EXISTS meta (key TEXT PRIMARY KEY, value TEXT NOT NULL)`); err != nil {
 		return fmt.Errorf("migrate: bootstrap meta: %w", err)
 	}
@@ -41,7 +48,7 @@ func Run(db *sql.DB, dataDir string, migrations []Migration) error {
 
 	ctx := Context{DB: db, DataDir: dataDir}
 
-	for _, m := range migrations {
+	for _, m := range sorted {
 		if m.Version <= current {
 			continue
 		}

--- a/internal/migrate/migrate_internal_test.go
+++ b/internal/migrate/migrate_internal_test.go
@@ -1,0 +1,25 @@
+package migrate
+
+import (
+	"database/sql"
+	"path/filepath"
+	"testing"
+
+	_ "github.com/mattn/go-sqlite3"
+)
+
+func TestCurrentVersionQueryError(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	db, err := sql.Open("sqlite3", filepath.Join(dir, "test.db"))
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	db.Exec(`CREATE TABLE meta (key TEXT PRIMARY KEY, value TEXT NOT NULL)`)
+	db.Close()
+
+	_, err = currentVersion(db)
+	if err == nil {
+		t.Fatal("expected error on closed db")
+	}
+}

--- a/internal/migrate/migrate_test.go
+++ b/internal/migrate/migrate_test.go
@@ -1,0 +1,182 @@
+package migrate_test
+
+import (
+	"database/sql"
+	"errors"
+	"path/filepath"
+	"testing"
+
+	_ "github.com/mattn/go-sqlite3"
+
+	"github.com/jacobjnilsson/sediment/internal/migrate"
+)
+
+func openDB(t *testing.T) *sql.DB {
+	t.Helper()
+	db, err := sql.Open("sqlite3", filepath.Join(t.TempDir(), "test.db"))
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+	return db
+}
+
+func TestRunNoMigrations(t *testing.T) {
+	t.Parallel()
+	db := openDB(t)
+	if err := migrate.Run(db, t.TempDir(), nil); err != nil {
+		t.Fatalf("Run(nil): %v", err)
+	}
+}
+
+func TestRunAppliesMigrations(t *testing.T) {
+	t.Parallel()
+	db := openDB(t)
+
+	migrations := []migrate.Migration{
+		{Version: 1, Description: "create users", Up: func(ctx migrate.Context) error {
+			_, err := ctx.DB.Exec(`CREATE TABLE users (id TEXT PRIMARY KEY)`)
+			return err
+		}},
+		{Version: 2, Description: "add name", Up: func(ctx migrate.Context) error {
+			_, err := ctx.DB.Exec(`ALTER TABLE users ADD COLUMN name TEXT`)
+			return err
+		}},
+	}
+
+	if err := migrate.Run(db, t.TempDir(), migrations); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	var name sql.NullString
+	err := db.QueryRow(`SELECT name FROM users WHERE id = 'test'`).Scan(&name)
+	if err != sql.ErrNoRows {
+		t.Errorf("expected ErrNoRows, got %v", err)
+	}
+}
+
+func TestRunSkipsApplied(t *testing.T) {
+	t.Parallel()
+	db := openDB(t)
+	dir := t.TempDir()
+
+	calls := 0
+	m := []migrate.Migration{
+		{Version: 1, Description: "first", Up: func(ctx migrate.Context) error {
+			calls++
+			return nil
+		}},
+	}
+
+	if err := migrate.Run(db, dir, m); err != nil {
+		t.Fatalf("first Run: %v", err)
+	}
+	if calls != 1 {
+		t.Fatalf("calls = %d, want 1", calls)
+	}
+
+	if err := migrate.Run(db, dir, m); err != nil {
+		t.Fatalf("second Run: %v", err)
+	}
+	if calls != 1 {
+		t.Errorf("calls = %d, want 1 (should skip)", calls)
+	}
+}
+
+func TestRunStopsOnError(t *testing.T) {
+	t.Parallel()
+	db := openDB(t)
+
+	migrations := []migrate.Migration{
+		{Version: 1, Description: "ok", Up: func(ctx migrate.Context) error {
+			return nil
+		}},
+		{Version: 2, Description: "fail", Up: func(ctx migrate.Context) error {
+			return errors.New("boom")
+		}},
+		{Version: 3, Description: "never", Up: func(ctx migrate.Context) error {
+			t.Fatal("should not reach v3")
+			return nil
+		}},
+	}
+
+	err := migrate.Run(db, t.TempDir(), migrations)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !errors.Is(err, errors.Unwrap(err)) {
+		// just check it wraps something
+	}
+}
+
+func TestRunPassesDataDir(t *testing.T) {
+	t.Parallel()
+	db := openDB(t)
+	dir := t.TempDir()
+
+	var gotDir string
+	m := []migrate.Migration{
+		{Version: 1, Description: "check dir", Up: func(ctx migrate.Context) error {
+			gotDir = ctx.DataDir
+			return nil
+		}},
+	}
+
+	if err := migrate.Run(db, dir, m); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if gotDir != dir {
+		t.Errorf("DataDir = %q, want %q", gotDir, dir)
+	}
+}
+
+func TestRunClosedDB(t *testing.T) {
+	t.Parallel()
+	db := openDB(t)
+	db.Close()
+
+	err := migrate.Run(db, t.TempDir(), nil)
+	if err == nil {
+		t.Fatal("expected error on closed db")
+	}
+}
+
+func TestRunSetVersionError(t *testing.T) {
+	t.Parallel()
+	db := openDB(t)
+	dir := t.TempDir()
+
+	m := []migrate.Migration{
+		{Version: 1, Description: "close db in migration", Up: func(ctx migrate.Context) error {
+			ctx.DB.Close()
+			return nil
+		}},
+	}
+
+	err := migrate.Run(db, dir, m)
+	if err == nil {
+		t.Fatal("expected error from setVersion on closed db")
+	}
+}
+
+func TestRunCurrentVersionParseError(t *testing.T) {
+	t.Parallel()
+	db := openDB(t)
+	dir := t.TempDir()
+
+	_, err := db.Exec(`CREATE TABLE IF NOT EXISTS meta (key TEXT PRIMARY KEY, value TEXT NOT NULL)`)
+	if err != nil {
+		t.Fatalf("create meta: %v", err)
+	}
+	_, err = db.Exec(`INSERT INTO meta (key, value) VALUES ('schema_version', 'garbage')`)
+	if err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+
+	err = migrate.Run(db, dir, []migrate.Migration{
+		{Version: 1, Description: "noop", Up: func(ctx migrate.Context) error { return nil }},
+	})
+	if err == nil {
+		t.Fatal("expected error from invalid schema_version")
+	}
+}

--- a/internal/migrate/migrate_test.go
+++ b/internal/migrate/migrate_test.go
@@ -109,6 +109,35 @@ func TestRunStopsOnError(t *testing.T) {
 	}
 }
 
+func TestRunSortsOutOfOrder(t *testing.T) {
+	t.Parallel()
+	db := openDB(t)
+
+	var order []int
+	migrations := []migrate.Migration{
+		{Version: 3, Description: "third", Up: func(ctx migrate.Context) error {
+			order = append(order, 3)
+			return nil
+		}},
+		{Version: 1, Description: "first", Up: func(ctx migrate.Context) error {
+			order = append(order, 1)
+			return nil
+		}},
+		{Version: 2, Description: "second", Up: func(ctx migrate.Context) error {
+			order = append(order, 2)
+			return nil
+		}},
+	}
+
+	if err := migrate.Run(db, t.TempDir(), migrations); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	if len(order) != 3 || order[0] != 1 || order[1] != 2 || order[2] != 3 {
+		t.Errorf("order = %v, want [1 2 3]", order)
+	}
+}
+
 func TestRunPassesDataDir(t *testing.T) {
 	t.Parallel()
 	db := openDB(t)

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -47,7 +47,6 @@ func Open(path string) (*DB, error) {
 	return &DB{conn: sqlDB, exec: sqlDB}, nil
 }
 
-// Migrate runs schema migrations to ensure tables exist.
 var migrations = []migrate.Migration{
 	{
 		Version:     1,
@@ -64,8 +63,7 @@ var migrations = []migrate.Migration{
 					updated_at       TEXT NOT NULL,
 					last_accessed_at TEXT NOT NULL,
 					tags             TEXT NOT NULL DEFAULT '[]',
-					source           TEXT NOT NULL DEFAULT '',
-					hardness         INTEGER NOT NULL DEFAULT 5
+					source           TEXT NOT NULL DEFAULT ''
 				);
 				CREATE INDEX IF NOT EXISTS idx_memories_state ON memories(state);
 				CREATE INDEX IF NOT EXISTS idx_memories_confidence ON memories(confidence);
@@ -73,10 +71,19 @@ var migrations = []migrate.Migration{
 			return err
 		},
 	},
+	{
+		Version:     2,
+		Description: "add hardness column",
+		Up: func(ctx migrate.Context) error {
+			_, err := ctx.DB.Exec(`ALTER TABLE memories ADD COLUMN hardness INTEGER NOT NULL DEFAULT 5`)
+			return err
+		},
+	},
 }
 
-func (d *DB) Migrate() error {
-	return migrate.Run(d.conn, "", migrations)
+// Migrate runs all pending schema and data migrations.
+func (d *DB) Migrate(dataDir string) error {
+	return migrate.Run(d.conn, dataDir, migrations)
 }
 
 func (d *DB) GetMeta(key string) (string, error) {

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -10,6 +10,7 @@ import (
 
 	_ "github.com/mattn/go-sqlite3" // SQLite driver
 
+	"github.com/jacobjnilsson/sediment/internal/migrate"
 	"github.com/jacobjnilsson/sediment/internal/model"
 )
 
@@ -47,36 +48,35 @@ func Open(path string) (*DB, error) {
 }
 
 // Migrate runs schema migrations to ensure tables exist.
+var migrations = []migrate.Migration{
+	{
+		Version:     1,
+		Description: "initial schema",
+		Up: func(ctx migrate.Context) error {
+			_, err := ctx.DB.Exec(`
+				CREATE TABLE IF NOT EXISTS memories (
+					id               TEXT PRIMARY KEY,
+					content          TEXT NOT NULL,
+					confidence       REAL NOT NULL DEFAULT 1.0,
+					state            TEXT NOT NULL DEFAULT 'active',
+					access_count     INTEGER NOT NULL DEFAULT 0,
+					created_at       TEXT NOT NULL,
+					updated_at       TEXT NOT NULL,
+					last_accessed_at TEXT NOT NULL,
+					tags             TEXT NOT NULL DEFAULT '[]',
+					source           TEXT NOT NULL DEFAULT '',
+					hardness         INTEGER NOT NULL DEFAULT 5
+				);
+				CREATE INDEX IF NOT EXISTS idx_memories_state ON memories(state);
+				CREATE INDEX IF NOT EXISTS idx_memories_confidence ON memories(confidence);
+			`)
+			return err
+		},
+	},
+}
+
 func (d *DB) Migrate() error {
-	const schema = `
-	CREATE TABLE IF NOT EXISTS memories (
-		id              TEXT PRIMARY KEY,
-		content         TEXT NOT NULL,
-		confidence      REAL NOT NULL DEFAULT 1.0,
-		state           TEXT NOT NULL DEFAULT 'active',
-		access_count    INTEGER NOT NULL DEFAULT 0,
-		created_at      TEXT NOT NULL,
-		updated_at      TEXT NOT NULL,
-		last_accessed_at TEXT NOT NULL,
-		tags            TEXT NOT NULL DEFAULT '[]',
-		source          TEXT NOT NULL DEFAULT '',
-		hardness        INTEGER NOT NULL DEFAULT 5
-	);
-	CREATE INDEX IF NOT EXISTS idx_memories_state ON memories(state);
-	CREATE INDEX IF NOT EXISTS idx_memories_confidence ON memories(confidence);
-	CREATE TABLE IF NOT EXISTS meta (
-		key   TEXT PRIMARY KEY,
-		value TEXT NOT NULL
-	);
-	`
-	_, err := d.exec.Exec(schema)
-	if err != nil {
-		return fmt.Errorf("migrate: %w", err)
-	}
-
-	d.exec.Exec(`ALTER TABLE memories ADD COLUMN hardness INTEGER NOT NULL DEFAULT 5`)
-
-	return nil
+	return migrate.Run(d.conn, "", migrations)
 }
 
 func (d *DB) GetMeta(key string) (string, error) {

--- a/internal/store/store_internal_test.go
+++ b/internal/store/store_internal_test.go
@@ -410,23 +410,3 @@ func TestMigrateMetaSchemaError(t *testing.T) {
 		t.Errorf("error = %q, want mention of migrate", err)
 	}
 }
-
-func TestMigrateAlterTableDuplicateColumn(t *testing.T) {
-	t.Parallel()
-	dir := t.TempDir()
-	dbPath := filepath.Join(dir, "dup.db")
-
-	conn, err := sql.Open("sqlite3", dbPath)
-	if err != nil {
-		t.Fatalf("open: %v", err)
-	}
-	defer conn.Close()
-
-	d := &DB{exec: conn, conn: conn}
-	if err := d.Migrate(); err != nil {
-		t.Fatalf("first migrate: %v", err)
-	}
-	if err := d.Migrate(); err != nil {
-		t.Fatalf("second migrate (duplicate column should be ignored): %v", err)
-	}
-}

--- a/internal/store/store_internal_test.go
+++ b/internal/store/store_internal_test.go
@@ -161,7 +161,7 @@ func TestInsertNilTagsViaDB(t *testing.T) {
 		t.Fatalf("open: %v", err)
 	}
 	defer d.Close()
-	if err := d.Migrate(); err != nil {
+	if err := d.Migrate(""); err != nil {
 		t.Fatalf("migrate: %v", err)
 	}
 
@@ -209,7 +209,7 @@ func TestRunInTxCommit(t *testing.T) {
 		t.Fatalf("open: %v", err)
 	}
 	defer d.Close()
-	if err := d.Migrate(); err != nil {
+	if err := d.Migrate(""); err != nil {
 		t.Fatalf("migrate: %v", err)
 	}
 
@@ -244,7 +244,7 @@ func TestRunInTxRollback(t *testing.T) {
 		t.Fatalf("open: %v", err)
 	}
 	defer d.Close()
-	if err := d.Migrate(); err != nil {
+	if err := d.Migrate(""); err != nil {
 		t.Fatalf("migrate: %v", err)
 	}
 
@@ -301,7 +301,7 @@ func TestRunInTxCommitError(t *testing.T) {
 		t.Fatalf("open: %v", err)
 	}
 	defer d.Close()
-	if err := d.Migrate(); err != nil {
+	if err := d.Migrate(""); err != nil {
 		t.Fatalf("migrate: %v", err)
 	}
 
@@ -336,7 +336,7 @@ func TestRunInTxMultipleOps(t *testing.T) {
 		t.Fatalf("open: %v", err)
 	}
 	defer d.Close()
-	if err := d.Migrate(); err != nil {
+	if err := d.Migrate(""); err != nil {
 		t.Fatalf("migrate: %v", err)
 	}
 
@@ -402,7 +402,7 @@ func TestMigrateMetaSchemaError(t *testing.T) {
 	defer conn.Close()
 
 	d := &DB{exec: conn, conn: conn}
-	err = d.Migrate()
+	err = d.Migrate("")
 	if err == nil {
 		t.Fatal("expected error on corrupt db")
 	}

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -20,7 +20,7 @@ func newTestDB(t *testing.T) *store.DB {
 	if err != nil {
 		t.Fatalf("open db: %v", err)
 	}
-	if err := db.Migrate(); err != nil {
+	if err := db.Migrate(""); err != nil {
 		t.Fatalf("migrate: %v", err)
 	}
 	t.Cleanup(func() { db.Close() })
@@ -70,7 +70,7 @@ func TestMigrate(t *testing.T) {
 	db := newTestDB(t)
 
 	// Running migrate twice should be idempotent.
-	if err := db.Migrate(); err != nil {
+	if err := db.Migrate(""); err != nil {
 		t.Fatalf("second migrate: %v", err)
 	}
 }
@@ -328,7 +328,7 @@ func TestListByStateOnClosedDB(t *testing.T) {
 	if err != nil {
 		t.Fatalf("open: %v", err)
 	}
-	if err := db.Migrate(); err != nil {
+	if err := db.Migrate(""); err != nil {
 		t.Fatalf("migrate: %v", err)
 	}
 	db.Close()
@@ -349,7 +349,7 @@ func TestListAllOnClosedDB(t *testing.T) {
 	if err != nil {
 		t.Fatalf("open: %v", err)
 	}
-	if err := db.Migrate(); err != nil {
+	if err := db.Migrate(""); err != nil {
 		t.Fatalf("migrate: %v", err)
 	}
 	db.Close()
@@ -370,7 +370,7 @@ func TestInsertOnClosedDB(t *testing.T) {
 	if err != nil {
 		t.Fatalf("open: %v", err)
 	}
-	if err := db.Migrate(); err != nil {
+	if err := db.Migrate(""); err != nil {
 		t.Fatalf("migrate: %v", err)
 	}
 	db.Close()
@@ -392,7 +392,7 @@ func TestUpdateOnClosedDB(t *testing.T) {
 	if err != nil {
 		t.Fatalf("open: %v", err)
 	}
-	if err := db.Migrate(); err != nil {
+	if err := db.Migrate(""); err != nil {
 		t.Fatalf("migrate: %v", err)
 	}
 	db.Close()
@@ -414,7 +414,7 @@ func TestDeleteOnClosedDB(t *testing.T) {
 	if err != nil {
 		t.Fatalf("open: %v", err)
 	}
-	if err := db.Migrate(); err != nil {
+	if err := db.Migrate(""); err != nil {
 		t.Fatalf("migrate: %v", err)
 	}
 	db.Close()
@@ -435,7 +435,7 @@ func TestGetOnClosedDB(t *testing.T) {
 	if err != nil {
 		t.Fatalf("open: %v", err)
 	}
-	if err := db.Migrate(); err != nil {
+	if err := db.Migrate(""); err != nil {
 		t.Fatalf("migrate: %v", err)
 	}
 	db.Close()
@@ -458,7 +458,7 @@ func TestMigrateOnClosedDB(t *testing.T) {
 	}
 	db.Close()
 
-	err = db.Migrate()
+	err = db.Migrate("")
 	if err == nil {
 		t.Fatal("expected error on closed db")
 	}
@@ -475,7 +475,7 @@ func TestMetaGetSetRoundTrip(t *testing.T) {
 		t.Fatalf("open: %v", err)
 	}
 	defer db.Close()
-	if err := db.Migrate(); err != nil {
+	if err := db.Migrate(""); err != nil {
 		t.Fatalf("migrate: %v", err)
 	}
 
@@ -515,10 +515,10 @@ func TestMigrateIdempotent(t *testing.T) {
 	if err != nil {
 		t.Fatalf("open: %v", err)
 	}
-	if err := db.Migrate(); err != nil {
+	if err := db.Migrate(""); err != nil {
 		t.Fatalf("migrate: %v", err)
 	}
-	if err := db.Migrate(); err != nil {
+	if err := db.Migrate(""); err != nil {
 		t.Fatalf("re-migrate should be idempotent: %v", err)
 	}
 	db.Close()
@@ -531,7 +531,7 @@ func TestSetMetaError(t *testing.T) {
 	if err != nil {
 		t.Fatalf("open: %v", err)
 	}
-	if err := db.Migrate(); err != nil {
+	if err := db.Migrate(""); err != nil {
 		t.Fatalf("migrate: %v", err)
 	}
 	db.Close()
@@ -549,7 +549,7 @@ func TestGetMetaError(t *testing.T) {
 	if err != nil {
 		t.Fatalf("open: %v", err)
 	}
-	if err := db.Migrate(); err != nil {
+	if err := db.Migrate(""); err != nil {
 		t.Fatalf("migrate: %v", err)
 	}
 	db.Close()


### PR DESCRIPTION
Releases often introduce breaking changes that go beyond SQL schema updates —
removing files, restructuring directories, rewriting configs. The existing
inline `Migrate()` could only do idempotent SQL.

This adds a general-purpose migration runner where each version is a Go function
with access to the database and filesystem. The existing schema setup becomes
migration v1, and future releases register additional migrations that run
automatically on startup.

Also fixes the pre-commit hook's main function grep pattern which broke when
the version variable shifted column alignment.

Closes #10