### PR TITLE
Fix double-escaping in plugin shell helper

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -27,6 +27,13 @@ fi
 
 rm -f coverage.out
 
+echo "==> plugin typecheck"
+if command -v bun >/dev/null 2>&1 && [ -f .opencode/tsconfig.json ]; then
+    (cd .opencode && bun tsc --noEmit)
+else
+    echo "    (skipped: bun not installed or tsconfig missing)"
+fi
+
 echo "==> plugin tests"
 if command -v bun >/dev/null 2>&1 && [ -f .opencode/plugins/sediment.test.ts ]; then
     bun test ./.opencode/plugins/sediment.test.ts

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -26,4 +26,12 @@ if [ -n "$UNCOVERED" ]; then
 fi
 
 rm -f coverage.out
+
+echo "==> plugin tests"
+if command -v bun >/dev/null 2>&1 && [ -f .opencode/plugins/sediment.test.ts ]; then
+    bun test ./.opencode/plugins/sediment.test.ts
+else
+    echo "    (skipped: bun not installed or test file missing)"
+fi
+
 echo "==> All checks passed"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,9 @@ jobs:
             exit 1
           fi
 
+      - name: Build sediment binary
+        run: go build -o /usr/local/bin/sediment ./cmd/sediment
+
       - uses: oven-sh/setup-bun@v2
 
       - name: Install plugin dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,3 +42,8 @@ jobs:
             echo "$UNCOVERED"
             exit 1
           fi
+
+      - uses: oven-sh/setup-bun@v2
+
+      - name: Plugin tests
+        run: bun test ./.opencode/plugins/sediment.test.ts

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,5 +45,13 @@ jobs:
 
       - uses: oven-sh/setup-bun@v2
 
+      - name: Install plugin dependencies
+        run: bun install
+        working-directory: .opencode
+
+      - name: Plugin typecheck
+        run: bun tsc --noEmit
+        working-directory: .opencode
+
       - name: Plugin tests
         run: bun test ./.opencode/plugins/sediment.test.ts

--- a/.opencode/plugins/sediment.test.ts
+++ b/.opencode/plugins/sediment.test.ts
@@ -1,0 +1,135 @@
+import { describe, test, expect } from "bun:test"
+import { $ } from "bun"
+import { unlinkSync } from "fs"
+
+function cleanup(path: string) {
+  try {
+    unlinkSync(path)
+  } catch {}
+}
+
+describe("shell helper: array interpolation", () => {
+  test("content with spaces preserved", async () => {
+    const dbPath = "/tmp/sediment-test-spaces.db"
+    cleanup(dbPath)
+
+    const args = ["deposit", "--content", "hello world", "--hardness", "5"]
+    const output = await $`sediment ${args} --db ${dbPath}`.quiet().text()
+    const parsed = JSON.parse(output)
+
+    expect(parsed.content).toBe("hello world")
+    expect(parsed.state).toBe("active")
+
+    cleanup(dbPath)
+  })
+
+  test("content with apostrophes preserved", async () => {
+    const dbPath = "/tmp/sediment-test-apos.db"
+    cleanup(dbPath)
+
+    const args = ["deposit", "--content", "it's a test", "--hardness", "5"]
+    const output = await $`sediment ${args} --db ${dbPath}`.quiet().text()
+    const parsed = JSON.parse(output)
+
+    expect(parsed.content).toBe("it's a test")
+
+    cleanup(dbPath)
+  })
+
+  test("content with quotes preserved", async () => {
+    const dbPath = "/tmp/sediment-test-quotes.db"
+    cleanup(dbPath)
+
+    const args = [
+      "deposit",
+      "--content",
+      'user said "hello"',
+      "--hardness",
+      "5",
+    ]
+    const output = await $`sediment ${args} --db ${dbPath}`.quiet().text()
+    const parsed = JSON.parse(output)
+
+    expect(parsed.content).toBe('user said "hello"')
+
+    cleanup(dbPath)
+  })
+
+  test("db path with spaces works", async () => {
+    const dbPath = "/tmp/sediment test path.db"
+    cleanup(dbPath)
+
+    const args = ["deposit", "--content", "test", "--hardness", "5"]
+    const output = await $`sediment ${args} --db ${dbPath}`.quiet().text()
+    const parsed = JSON.parse(output)
+
+    expect(parsed.content).toBe("test")
+
+    cleanup(dbPath)
+  })
+
+  test("strata command works", async () => {
+    const dbPath = "/tmp/sediment-test-strata.db"
+    cleanup(dbPath)
+
+    await $`sediment deposit --content "memory one" --hardness 5 --db ${dbPath}`.quiet()
+    const args = ["strata"]
+    const output = await $`sediment ${args} --db ${dbPath}`.quiet().text()
+
+    expect(output).toContain("memory one")
+
+    cleanup(dbPath)
+  })
+
+  test("tags with commas preserved", async () => {
+    const dbPath = "/tmp/sediment-test-tags.db"
+    cleanup(dbPath)
+
+    const args = [
+      "deposit",
+      "--content",
+      "tagged memory",
+      "--hardness",
+      "5",
+      "--tags",
+      "foo,bar,baz",
+    ]
+    const output = await $`sediment ${args} --db ${dbPath}`.quiet().text()
+    const parsed = JSON.parse(output)
+
+    expect(parsed.content).toBe("tagged memory")
+    expect(parsed.tags).toContain("foo")
+    expect(parsed.tags).toContain("bar")
+
+    cleanup(dbPath)
+  })
+})
+
+describe("regression: escaped.join() double-escapes", () => {
+  test("pre-escaped args joined as string corrupt content", async () => {
+    const dbPath = "/tmp/sediment-test-regression.db"
+    cleanup(dbPath)
+
+    const args = ["deposit", "--content", "hello world", "--hardness", "5"]
+    const escaped = args.map((a) => $.escape(a))
+    const escapedDb = $.escape(dbPath)
+
+    let output = ""
+    let failed = false
+    try {
+      output =
+        await $`sediment ${escaped.join(" ")} --db ${escapedDb}`.quiet().text()
+    } catch {
+      failed = true
+    }
+
+    if (!failed) {
+      const parsed = JSON.parse(output)
+      expect(parsed.content).not.toBe("hello world")
+    } else {
+      expect(failed).toBe(true)
+    }
+
+    cleanup(dbPath)
+  })
+})

--- a/.opencode/plugins/sediment.ts
+++ b/.opencode/plugins/sediment.ts
@@ -18,10 +18,7 @@ export const SedimentPlugin: Plugin = async ({ $, directory }) => {
   const dbPath = `${directory}/.sediment.db`
 
   const sediment = async (args: string[]) => {
-    const escaped = args.map((a) => $.escape(a))
-    const escapedDb = $.escape(dbPath)
-    const result =
-      await $`sediment ${escaped.join(" ")} --db ${escapedDb}`.quiet()
+    const result = await $`sediment ${args} --db ${dbPath}`.quiet()
     return result.text().trim()
   }
 

--- a/.opencode/tsconfig.json
+++ b/.opencode/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "strict": true,
+    "noEmit": true,
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "target": "ESNext",
+    "skipLibCheck": true
+  },
+  "include": ["plugins/**/*.ts"],
+  "exclude": ["plugins/**/*.test.ts"]
+}


### PR DESCRIPTION
## Summary

The opencode plugin's shell helper manually escaped args with `$.escape()` then
joined them into a single string before passing to a Bun shell template literal.
Bun's tagged template already escapes array expressions per-token, so this caused
double-escaping — corrupting any memory content containing spaces, quotes, or
apostrophes.

This produced malformed CLI output that eventually crashed opencode sessions with
`Input should be a valid dictionary`, making the repo unusable until the session
state was cleared.

The fix passes the args array directly to the template literal and removes the
redundant manual escaping.