### PR TITLE
Fix plugin hook that caused OpenCode to stall

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -29,7 +29,7 @@ rm -f coverage.out
 
 echo "==> plugin typecheck"
 if command -v bun >/dev/null 2>&1 && [ -f .opencode/tsconfig.json ]; then
-    (cd .opencode && bun tsc --noEmit)
+    (cd .opencode &&     bun run typecheck)
 else
     echo "    (skipped: bun not installed or tsconfig missing)"
 fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
         working-directory: .opencode
 
       - name: Plugin typecheck
-        run: bun tsc --noEmit
+        run: bun run typecheck
         working-directory: .opencode
 
       - name: Plugin tests

--- a/.opencode/package.json
+++ b/.opencode/package.json
@@ -1,10 +1,15 @@
 {
   "private": true,
+  "scripts": {
+    "typecheck": "tsc --noEmit",
+    "test": "bun test ./plugins/sediment.test.ts"
+  },
   "dependencies": {
-    "@opencode-ai/plugin": "latest"
+    "@opencode-ai/plugin": "1.4.3"
   },
   "devDependencies": {
     "@types/node": "^25.6.0",
+    "bun-types": "^1.3.13",
     "typescript": "^6.0.3"
   }
 }

--- a/.opencode/plugins/sediment.test.ts
+++ b/.opencode/plugins/sediment.test.ts
@@ -1,6 +1,9 @@
-import { describe, test, expect } from "bun:test"
+import { describe, test, expect, beforeEach, afterEach } from "bun:test"
 import { $ } from "bun"
-import { unlinkSync } from "fs"
+import { unlinkSync, mkdtempSync } from "fs"
+import { tmpdir } from "os"
+import { join } from "path"
+import { SedimentPlugin } from "./sediment"
 
 function cleanup(path: string) {
   try {
@@ -102,6 +105,60 @@ describe("shell helper: array interpolation", () => {
     expect(parsed.tags).toContain("bar")
 
     cleanup(dbPath)
+  })
+})
+
+describe("plugin hooks", () => {
+  let tmpDir: string
+  let dbPath: string
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "sediment-plugin-test-"))
+    dbPath = join(tmpDir, ".sediment.db")
+  })
+
+  afterEach(() => {
+    cleanup(dbPath)
+  })
+
+  async function makePlugin() {
+    // Minimal stub for the plugin context
+    const pluginCtx = {
+      $,
+      directory: tmpDir,
+    } as any
+    return SedimentPlugin(pluginCtx)
+  }
+
+  test("registers experimental.chat.system.transform hook", async () => {
+    const hooks = await makePlugin()
+    expect(typeof hooks["experimental.chat.system.transform"]).toBe("function")
+  })
+
+  test("does NOT register chat.message hook", async () => {
+    const hooks = await makePlugin()
+    expect(hooks["chat.message"]).toBeUndefined()
+  })
+
+  test("system transform injects deposit instruction into system array", async () => {
+    const hooks = await makePlugin()
+    const systemTransform = hooks["experimental.chat.system.transform"] as Function
+    const output = { system: [] as string[] }
+    await systemTransform({}, output)
+    expect(output.system.some((s: string) => s.includes("sediment_deposit"))).toBe(true)
+  })
+
+  test("system transform injects active memories when db has entries", async () => {
+    // Deposit a memory first
+    await $`sediment deposit --content "test memory fact" --hardness 7 --db ${dbPath}`.quiet()
+
+    const hooks = await makePlugin()
+    const systemTransform = hooks["experimental.chat.system.transform"] as Function
+    const output = { system: [] as string[] }
+    await systemTransform({}, output)
+
+    const combined = output.system.join("\n")
+    expect(combined).toContain("test memory fact")
   })
 })
 

--- a/.opencode/plugins/sediment.ts
+++ b/.opencode/plugins/sediment.ts
@@ -1,5 +1,4 @@
-import type { Plugin } from "@opencode-ai/plugin"
-import type { Part } from "@opencode-ai/sdk"
+import type { Plugin, Hooks } from "@opencode-ai/plugin"
 import { tool } from "@opencode-ai/plugin"
 
 const DEPOSIT_INSTRUCTION = `## Memory Protocol
@@ -32,11 +31,13 @@ export const SedimentPlugin: Plugin = async ({ $, directory }) => {
   }
 
   return {
-    "chat.message": async (_input, output) => {
-      output.parts.push({
-        type: "text",
-        text: DEPOSIT_INSTRUCTION,
-      } as Part)
+    "experimental.chat.system.transform": async (_input, output) => {
+      output.system.push(DEPOSIT_INSTRUCTION)
+      if (activeMemories) {
+        output.system.push(
+          `## Sediment Memories (persistent across sessions)\n${activeMemories}`,
+        )
+      }
     },
 
     "experimental.session.compacting": async (_input, output) => {
@@ -124,5 +125,5 @@ export const SedimentPlugin: Plugin = async ({ $, directory }) => {
         },
       }),
     },
-  }
+  } satisfies Hooks
 }

--- a/.opencode/tsconfig.json
+++ b/.opencode/tsconfig.json
@@ -5,8 +5,8 @@
     "module": "ESNext",
     "moduleResolution": "bundler",
     "target": "ESNext",
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "types": ["bun-types"]
   },
-  "include": ["plugins/**/*.ts"],
-  "exclude": ["plugins/**/*.test.ts"]
+  "include": ["plugins/**/*.ts"]
 }


### PR DESCRIPTION
The sediment OpenCode plugin was using the `chat.message` hook to inject memory context and instructions. That hook is intended for modifying user messages — pushing raw objects into `output.parts` caused OpenCode to produce visual artifacts and stop responding.

Switched to `experimental.chat.system.transform`, which appends strings to `output.system[]` and is the correct mechanism for injecting persistent context into every request.

To make this class of mistake impossible going forward, the plugin return value is now annotated with `satisfies Hooks`. This means tsc will immediately error on an unknown hook name or a mismatched output shape — at save time, before tests run. Test files are now included in tsconfig (with `bun-types` added so bun globals resolve), and a `typecheck` script runs in both the pre-commit hook and CI.