### PR TITLE
Install sediment as a global OpenCode plugin

### DIFF
--- a/.opencode/plugins/sediment.test.ts
+++ b/.opencode/plugins/sediment.test.ts
@@ -130,17 +130,31 @@ describe("plugin hooks", () => {
     return SedimentPlugin(pluginCtx)
   }
 
-  test("registers experimental.chat.system.transform hook", async () => {
+  test("returns empty hooks when no .sediment.db exists", async () => {
+    const hooks = await makePlugin()
+    expect(hooks).toEqual({})
+  })
+
+  test("registers hooks when .sediment.db exists", async () => {
+    // Create the database so the plugin activates
+    await $`sediment init --db ${dbPath}`.quiet()
+
     const hooks = await makePlugin()
     expect(typeof hooks["experimental.chat.system.transform"]).toBe("function")
+    expect(typeof hooks["experimental.session.compacting"]).toBe("function")
+    expect(hooks["tool"]).toBeDefined()
   })
 
   test("does NOT register chat.message hook", async () => {
+    await $`sediment init --db ${dbPath}`.quiet()
+
     const hooks = await makePlugin()
     expect(hooks["chat.message"]).toBeUndefined()
   })
 
   test("system transform injects deposit instruction into system array", async () => {
+    await $`sediment init --db ${dbPath}`.quiet()
+
     const hooks = await makePlugin()
     const systemTransform = hooks["experimental.chat.system.transform"] as Function
     const output = { system: [] as string[] }
@@ -149,7 +163,7 @@ describe("plugin hooks", () => {
   })
 
   test("system transform injects active memories when db has entries", async () => {
-    // Deposit a memory first
+    // Deposit a memory first (also creates the db)
     await $`sediment deposit --content "test memory fact" --hardness 7 --db ${dbPath}`.quiet()
 
     const hooks = await makePlugin()

--- a/.opencode/plugins/sediment.ts
+++ b/.opencode/plugins/sediment.ts
@@ -1,5 +1,6 @@
 import type { Plugin, Hooks } from "@opencode-ai/plugin"
 import { tool } from "@opencode-ai/plugin"
+import { existsSync } from "fs"
 
 const DEPOSIT_INSTRUCTION = `## Memory Protocol
 You have persistent memory via the \`sediment_deposit\` tool. After each response,
@@ -16,6 +17,10 @@ Current memories are available in context — check for contradictions before de
 export const SedimentPlugin: Plugin = async ({ $, directory }) => {
   const dbPath = `${directory}/.sediment.db`
 
+  if (!existsSync(dbPath)) {
+    return {} satisfies Hooks
+  }
+
   const sediment = async (args: string[]) => {
     const result = await $`sediment ${args} --db ${dbPath}`.quiet()
     return result.text().trim()
@@ -27,7 +32,7 @@ export const SedimentPlugin: Plugin = async ({ $, directory }) => {
     await sediment(["erode", "--auto"])
     activeMemories = await sediment(["strata"])
   } catch {
-    // sediment not initialized or not installed
+    // sediment CLI not installed — degrade gracefully
   }
 
   return {

--- a/README.md
+++ b/README.md
@@ -22,11 +22,7 @@ Accessing a memory (excavating it) boosts its confidence and can reverse decay.
 
 ## Install
 
-```sh
-brew install jacobjnilsson/tap/sediment   # or download from GitHub releases
-```
-
-Then set up a project:
+Download the latest binary from [GitHub releases](https://github.com/JacobJNilsson/sediment/releases), then set up a project:
 
 ```sh
 cd your-project
@@ -51,10 +47,10 @@ All commands accept `--db <path>` to override the default `.sediment.db`. All ou
 
 ## OpenCode plugin
 
-The plugin runs automatically when OpenCode opens the repo. On each session it:
+The `sediment setup` wizard installs the plugin globally to `~/.config/opencode/plugins/sediment.ts`. It runs in every OpenCode session but only activates when a `.sediment.db` exists in the working directory, so repos that haven't been set up are unaffected.
 
-1. Runs `erode --auto` to apply decay since last session.
+On each session in a set-up repo, the plugin:
+
+1. Runs `erode --auto` to apply decay since the last session.
 2. Loads active and dormant memories into the system prompt.
 3. Instructs the agent to deposit new reusable knowledge via the `sediment_deposit` tool.
-
-> **Note:** The plugin currently lives in `.opencode/plugins/` and only activates inside this repo. Global installation (so it runs in every project) is [tracked in #17](https://github.com/JacobJNilsson/sediment/issues/17).

--- a/cmd/sediment/main.go
+++ b/cmd/sediment/main.go
@@ -91,6 +91,152 @@ sediment erode
 - **The .sediment.db file should be gitignored.** It contains local agent context, not project source.
 `
 
+const pluginContent = `import type { Plugin, Hooks } from "@opencode-ai/plugin"
+import { tool } from "@opencode-ai/plugin"
+import { existsSync } from "fs"
+
+const DEPOSIT_INSTRUCTION = ` + "`" + `## Memory Protocol
+You have persistent memory via the ` + "\\`" + `sediment_deposit` + "\\`" + ` tool. After each response,
+consider: did I learn something about the user, project, or codebase worth
+remembering in a future session? If yes, call sediment_deposit with:
+- content: concise single-statement fact
+- hardness: 1-3 for ephemeral, 4-6 for decisions/preferences, 7-10 for conventions/patterns
+- tags: relevant categories
+- supersedes_id: ID of contradicted memory (if applicable)
+
+Most turns require zero deposits. Only deposit genuinely new, reusable knowledge.
+Current memories are available in context — check for contradictions before depositing.` + "`" + `
+
+export const SedimentPlugin: Plugin = async ({ $, directory }) => {
+  const dbPath = ` + "`${directory}/.sediment.db`" + `
+
+  if (!existsSync(dbPath)) {
+    return {} satisfies Hooks
+  }
+
+  const sediment = async (args: string[]) => {
+    const result = await $` + "`sediment ${args} --db ${dbPath}`" + `.quiet()
+    return result.text().trim()
+  }
+
+  let activeMemories: string | null = null
+
+  try {
+    await sediment(["erode", "--auto"])
+    activeMemories = await sediment(["strata"])
+  } catch {
+    // sediment CLI not installed — degrade gracefully
+  }
+
+  return {
+    "experimental.chat.system.transform": async (_input, output) => {
+      output.system.push(DEPOSIT_INSTRUCTION)
+      if (activeMemories) {
+        output.system.push(
+          ` + "`## Sediment Memories (persistent across sessions)\\n${activeMemories}`" + `,
+        )
+      }
+    },
+
+    "experimental.session.compacting": async (_input, output) => {
+      try {
+        activeMemories = await sediment(["strata"])
+      } catch {
+        // fall back to cached
+      }
+      if (activeMemories) {
+        output.context.push(
+          ` + "`## Sediment Memories (persistent across sessions)\\n${activeMemories}`" + `,
+        )
+      }
+    },
+
+    tool: {
+      sediment_deposit: tool({
+        description: [
+          "Store a memory for future sessions. Use this after learning something worth",
+          "remembering about the user, project, or codebase.",
+          "",
+          "Hardness uses Mohs scale (1-10):",
+          "  1-3 (Talc-Calcite): situational, one-off comments, ephemeral context",
+          "  4-6 (Fluorite-Feldspar): decisions, preferences, architectural choices",
+          "  7-10 (Quartz-Diamond): conventions, patterns, testing approach, team rules",
+          "",
+          "Contradiction handling: if the new memory contradicts an existing one,",
+          "set supersedes_id to the ID of the old memory. The old memory will be",
+          "archived and replaced.",
+        ].join("\n"),
+        args: {
+          content: tool.schema.string(),
+          tags: tool.schema.array(tool.schema.string()).optional(),
+          hardness: tool.schema.number().min(1).max(10).optional(),
+          supersedes_id: tool.schema.string().optional(),
+        },
+        async execute(args) {
+          if (args.supersedes_id) {
+            try {
+              await sediment([
+                "resolve",
+                "--action",
+                "supersede",
+                "--id",
+                args.supersedes_id,
+                "--content",
+                args.content,
+              ])
+              return ` + "`Superseded memory ${args.supersedes_id} with: ${args.content}`" + `
+            } catch (e) {
+              return ` + "`Failed to supersede: ${e}`" + `
+            }
+          }
+
+          const depositArgs = [
+            "deposit",
+            "--content",
+            args.content,
+            "--hardness",
+            String(args.hardness ?? 5),
+          ]
+          if (args.tags?.length) {
+            depositArgs.push("--tags", args.tags.join(","))
+          }
+          try {
+            return await sediment(depositArgs)
+          } catch (e) {
+            return ` + "`Failed to deposit: ${e}`" + `
+          }
+        },
+      }),
+
+      sediment_recall: tool({
+        description:
+          "Retrieve all active and dormant memories from previous sessions. " +
+          "Use at the start of a session if memories were not auto-loaded, " +
+          "or to refresh context mid-session.",
+        args: {},
+        async execute() {
+          try {
+            return await sediment(["strata"])
+          } catch (e) {
+            return ` + "`Failed to recall: ${e}`" + `
+          }
+        },
+      }),
+    },
+  } satisfies Hooks
+}
+`
+
+const pluginDepVersion = "1.4.3"
+
+const pluginPkgJSON = `{
+  "private": true,
+  "dependencies": {
+    "@opencode-ai/plugin": "` + pluginDepVersion + `"
+  }
+}
+`
+
 const globalUsage = `sediment - AI memory lifecycle manager
 
 Memories are deposited, decay over time, get reinforced through access,
@@ -974,13 +1120,15 @@ func cmdSetup(args []string, w io.Writer) error {
 		return fmt.Errorf("setup cancelled: %w", err)
 	}
 
+	home, err := userHomeDir()
+	if err != nil {
+		return fmt.Errorf("resolve home directory: %w", err)
+	}
+
+	// Skill installation (global or workspace).
 	var skillDir string
 	switch cfg.Scope {
 	case "global":
-		home, err := userHomeDir()
-		if err != nil {
-			return fmt.Errorf("resolve home directory: %w", err)
-		}
 		skillDir = filepath.Join(home, ".agents", "skills", "sediment")
 	case "workspace":
 		skillDir = filepath.Join(".agents", "skills", "sediment")
@@ -997,6 +1145,13 @@ func cmdSetup(args []string, w io.Writer) error {
 
 	absSkillPath, _ := filepath.Abs(skillPath)
 
+	// Plugin installation (always global).
+	pluginPath, err := installPlugin(home)
+	if err != nil {
+		return err
+	}
+
+	// Database initialisation (repo-local).
 	db, absDBPath, err := openAndMigrate(args)
 	if err != nil {
 		return err
@@ -1008,6 +1163,7 @@ func cmdSetup(args []string, w io.Writer) error {
 	fmt.Fprintln(w)
 	fmt.Fprintln(w, "Setup complete!")
 	fmt.Fprintln(w)
+	fmt.Fprintf(w, "  Plugin:    %s\n", pluginPath)
 	fmt.Fprintf(w, "  Skill:     %s\n", absSkillPath)
 	fmt.Fprintf(w, "  Database:  %s\n", absDBPath)
 	if gitignoreUpdated {
@@ -1016,6 +1172,71 @@ func cmdSetup(args []string, w io.Writer) error {
 	fmt.Fprintln(w)
 	fmt.Fprintln(w, "Start a new agent session — it will pick up your memories automatically.")
 
+	return nil
+}
+
+// installPlugin writes the OpenCode plugin and its package.json to the global
+// config directory (~/.config/opencode/). If a package.json already exists it
+// is preserved and the dependency is merged in.
+func installPlugin(home string) (string, error) {
+	configDir := filepath.Join(home, ".config", "opencode")
+	pluginDir := filepath.Join(configDir, "plugins")
+
+	if err := os.MkdirAll(pluginDir, 0o755); err != nil {
+		return "", fmt.Errorf("create plugin directory: %w", err)
+	}
+
+	pluginPath := filepath.Join(pluginDir, "sediment.ts")
+	if err := writeFile(pluginPath, []byte(pluginContent), 0o644); err != nil {
+		return "", fmt.Errorf("write plugin file: %w", err)
+	}
+
+	if err := ensurePluginDeps(configDir, os.Stderr); err != nil {
+		return "", err
+	}
+
+	return pluginPath, nil
+}
+
+// ensurePluginDeps makes sure the OpenCode config package.json contains the
+// @opencode-ai/plugin dependency. If the file doesn't exist it is created
+// from pluginPkgJSON. If it exists the dependency is merged without
+// overwriting other entries.
+func ensurePluginDeps(configDir string, w io.Writer) error {
+	pkgPath := filepath.Join(configDir, "package.json")
+	existing, err := os.ReadFile(pkgPath)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			return fmt.Errorf("read plugin dependencies: %w", err)
+		}
+		if err := writeFile(pkgPath, []byte(pluginPkgJSON), 0o644); err != nil {
+			return fmt.Errorf("write plugin dependencies: %w", err)
+		}
+		return nil
+	}
+
+	var pkg map[string]any
+	if err := json.Unmarshal(existing, &pkg); err != nil {
+		fmt.Fprintf(w, "warning: existing package.json was malformed, replacing it\n")
+		if err := writeFile(pkgPath, []byte(pluginPkgJSON), 0o644); err != nil {
+			return fmt.Errorf("write plugin dependencies: %w", err)
+		}
+		return nil
+	}
+
+	deps, ok := pkg["dependencies"].(map[string]any)
+	if !ok {
+		deps = map[string]any{}
+		pkg["dependencies"] = deps
+	}
+	deps["@opencode-ai/plugin"] = pluginDepVersion
+
+	// json.MarshalIndent cannot fail on map[string]any with basic-type values.
+	out, _ := json.MarshalIndent(pkg, "", "  ")
+	out = append(out, '\n')
+	if err := writeFile(pkgPath, out, 0o644); err != nil {
+		return fmt.Errorf("write plugin dependencies: %w", err)
+	}
 	return nil
 }
 

--- a/cmd/sediment/main_test.go
+++ b/cmd/sediment/main_test.go
@@ -2279,6 +2279,25 @@ func TestCmdSetupGlobalScope(t *testing.T) {
 		t.Error("skill file missing expected content")
 	}
 
+	// Plugin should be installed globally.
+	pluginPath := filepath.Join(dir, ".config", "opencode", "plugins", "sediment.ts")
+	pluginData, err := os.ReadFile(pluginPath)
+	if err != nil {
+		t.Fatalf("read plugin: %v", err)
+	}
+	if !strings.Contains(string(pluginData), "SedimentPlugin") {
+		t.Error("plugin file missing expected content")
+	}
+
+	// package.json should have the plugin dependency.
+	pkgData, err := os.ReadFile(filepath.Join(dir, ".config", "opencode", "package.json"))
+	if err != nil {
+		t.Fatalf("read package.json: %v", err)
+	}
+	if !strings.Contains(string(pkgData), "@opencode-ai/plugin") {
+		t.Error("package.json missing plugin dependency")
+	}
+
 	if _, err := os.Stat(filepath.Join(dir, ".sediment.db")); os.IsNotExist(err) {
 		t.Error("database was not created")
 	}
@@ -2287,10 +2306,19 @@ func TestCmdSetupGlobalScope(t *testing.T) {
 	if !strings.Contains(string(gi), ".sediment.db") {
 		t.Error("gitignore not updated")
 	}
+
+	if !strings.Contains(output, "Plugin:") {
+		t.Error("output missing plugin path")
+	}
 }
 
 func TestCmdSetupWorkspaceScope(t *testing.T) {
 	dir := t.TempDir()
+	home := t.TempDir()
+	oldHome := os.Getenv("HOME")
+	os.Setenv("HOME", home)
+	t.Cleanup(func() { os.Setenv("HOME", oldHome) })
+
 	oldWd, _ := os.Getwd()
 	os.Chdir(dir)
 	t.Cleanup(func() { os.Chdir(oldWd) })
@@ -2306,9 +2334,16 @@ func TestCmdSetupWorkspaceScope(t *testing.T) {
 		t.Fatalf("setup: %v", err)
 	}
 
+	// Skill installed at workspace level.
 	skillPath := filepath.Join(dir, ".agents", "skills", "sediment", "SKILL.md")
 	if _, err := os.Stat(skillPath); os.IsNotExist(err) {
 		t.Fatal("workspace skill file not created")
+	}
+
+	// Plugin still installed globally.
+	pluginPath := filepath.Join(home, ".config", "opencode", "plugins", "sediment.ts")
+	if _, err := os.Stat(pluginPath); os.IsNotExist(err) {
+		t.Fatal("global plugin file not created")
 	}
 }
 
@@ -2373,6 +2408,11 @@ func TestCmdSetupInvalidDB(t *testing.T) {
 	defer restore()
 
 	dir := t.TempDir()
+	home := t.TempDir()
+	oldHome := os.Getenv("HOME")
+	os.Setenv("HOME", home)
+	t.Cleanup(func() { os.Setenv("HOME", oldHome) })
+
 	oldWd, _ := os.Getwd()
 	os.Chdir(dir)
 	t.Cleanup(func() { os.Chdir(oldWd) })
@@ -2420,6 +2460,11 @@ func TestCmdSetupGitignoreNoTrailingNewline(t *testing.T) {
 
 func TestCmdSetupSkillDirPermissionDenied(t *testing.T) {
 	dir := t.TempDir()
+	home := t.TempDir()
+	oldHome := os.Getenv("HOME")
+	os.Setenv("HOME", home)
+	t.Cleanup(func() { os.Setenv("HOME", oldHome) })
+
 	oldWd, _ := os.Getwd()
 	os.Chdir(dir)
 	t.Cleanup(func() { os.Chdir(oldWd) })
@@ -2442,6 +2487,11 @@ func TestCmdSetupSkillDirPermissionDenied(t *testing.T) {
 
 func TestCmdSetupWriteSkillError(t *testing.T) {
 	dir := t.TempDir()
+	home := t.TempDir()
+	oldHome := os.Getenv("HOME")
+	os.Setenv("HOME", home)
+	t.Cleanup(func() { os.Setenv("HOME", oldHome) })
+
 	oldWd, _ := os.Getwd()
 	os.Chdir(dir)
 	t.Cleanup(func() { os.Chdir(oldWd) })
@@ -2482,6 +2532,311 @@ func TestCmdSetupHomeDirError(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "resolve home directory") {
 		t.Errorf("error = %q, want 'resolve home directory'", err)
+	}
+}
+
+func TestCmdSetupPluginMergesExistingPackageJSON(t *testing.T) {
+	dir := t.TempDir()
+	oldHome := os.Getenv("HOME")
+	os.Setenv("HOME", dir)
+	t.Cleanup(func() { os.Setenv("HOME", oldHome) })
+
+	oldWd, _ := os.Getwd()
+	os.Chdir(dir)
+	t.Cleanup(func() { os.Chdir(oldWd) })
+
+	// Pre-existing package.json with another dependency.
+	configDir := filepath.Join(dir, ".config", "opencode")
+	os.MkdirAll(configDir, 0o755)
+	os.WriteFile(filepath.Join(configDir, "package.json"),
+		[]byte(`{"dependencies":{"other-plugin":"2.0.0"}}`), 0o644)
+
+	restore := mockForm("opencode", "global")
+	defer restore()
+
+	var buf bytes.Buffer
+	err := cmdSetup(nil, &buf)
+	if err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+
+	pkgData, err := os.ReadFile(filepath.Join(configDir, "package.json"))
+	if err != nil {
+		t.Fatalf("read package.json: %v", err)
+	}
+	content := string(pkgData)
+	if !strings.Contains(content, "@opencode-ai/plugin") {
+		t.Error("package.json missing sediment plugin dependency")
+	}
+	if !strings.Contains(content, "other-plugin") {
+		t.Error("package.json lost existing dependency")
+	}
+}
+
+func TestCmdSetupPluginOverwritesMalformedPackageJSON(t *testing.T) {
+	dir := t.TempDir()
+	oldHome := os.Getenv("HOME")
+	os.Setenv("HOME", dir)
+	t.Cleanup(func() { os.Setenv("HOME", oldHome) })
+
+	oldWd, _ := os.Getwd()
+	os.Chdir(dir)
+	t.Cleanup(func() { os.Chdir(oldWd) })
+
+	// Malformed package.json.
+	configDir := filepath.Join(dir, ".config", "opencode")
+	os.MkdirAll(configDir, 0o755)
+	os.WriteFile(filepath.Join(configDir, "package.json"),
+		[]byte(`not json`), 0o644)
+
+	restore := mockForm("opencode", "global")
+	defer restore()
+
+	var buf bytes.Buffer
+	err := cmdSetup(nil, &buf)
+	if err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+
+	pkgData, err := os.ReadFile(filepath.Join(configDir, "package.json"))
+	if err != nil {
+		t.Fatalf("read package.json: %v", err)
+	}
+	if !strings.Contains(string(pkgData), "@opencode-ai/plugin") {
+		t.Error("package.json missing plugin dependency after overwrite")
+	}
+}
+
+func TestCmdSetupWritePluginError(t *testing.T) {
+	dir := t.TempDir()
+	home := t.TempDir()
+	oldHome := os.Getenv("HOME")
+	os.Setenv("HOME", home)
+	t.Cleanup(func() { os.Setenv("HOME", oldHome) })
+
+	oldWd, _ := os.Getwd()
+	os.Chdir(dir)
+	t.Cleanup(func() { os.Chdir(oldWd) })
+
+	restore := mockForm("opencode", "workspace")
+	defer restore()
+
+	old := writeFile
+	writeFile = func(name string, data []byte, perm os.FileMode) error {
+		if strings.HasSuffix(name, "sediment.ts") {
+			return fmt.Errorf("disk full")
+		}
+		return old(name, data, perm)
+	}
+	t.Cleanup(func() { writeFile = old })
+
+	var buf bytes.Buffer
+	err := cmdSetup(nil, &buf)
+	if err == nil {
+		t.Fatal("expected write error")
+	}
+	if !strings.Contains(err.Error(), "write plugin file") {
+		t.Errorf("error = %q, want 'write plugin file'", err)
+	}
+}
+
+func TestCmdSetupPluginDirBlocked(t *testing.T) {
+	dir := t.TempDir()
+	home := t.TempDir()
+	oldHome := os.Getenv("HOME")
+	os.Setenv("HOME", home)
+	t.Cleanup(func() { os.Setenv("HOME", oldHome) })
+
+	oldWd, _ := os.Getwd()
+	os.Chdir(dir)
+	t.Cleanup(func() { os.Chdir(oldWd) })
+
+	// Place a regular file where the plugins directory should go.
+	configDir := filepath.Join(home, ".config", "opencode")
+	os.MkdirAll(configDir, 0o755)
+	os.WriteFile(filepath.Join(configDir, "plugins"), []byte("blocker"), 0o644)
+
+	restore := mockForm("opencode", "workspace")
+	defer restore()
+
+	var buf bytes.Buffer
+	err := cmdSetup(nil, &buf)
+	if err == nil {
+		t.Fatal("expected error for blocked plugin directory")
+	}
+	if !strings.Contains(err.Error(), "create plugin directory") {
+		t.Errorf("error = %q, want 'create plugin directory'", err)
+	}
+}
+
+func TestCmdSetupPluginDepsWriteError(t *testing.T) {
+	dir := t.TempDir()
+	home := t.TempDir()
+	oldHome := os.Getenv("HOME")
+	os.Setenv("HOME", home)
+	t.Cleanup(func() { os.Setenv("HOME", oldHome) })
+
+	oldWd, _ := os.Getwd()
+	os.Chdir(dir)
+	t.Cleanup(func() { os.Chdir(oldWd) })
+
+	restore := mockForm("opencode", "workspace")
+	defer restore()
+
+	old := writeFile
+	writeFile = func(name string, data []byte, perm os.FileMode) error {
+		if strings.HasSuffix(name, "package.json") {
+			return fmt.Errorf("disk full")
+		}
+		return old(name, data, perm)
+	}
+	t.Cleanup(func() { writeFile = old })
+
+	var buf bytes.Buffer
+	err := cmdSetup(nil, &buf)
+	if err == nil {
+		t.Fatal("expected write error for package.json")
+	}
+	if !strings.Contains(err.Error(), "write plugin dependencies") {
+		t.Errorf("error = %q, want 'write plugin dependencies'", err)
+	}
+}
+
+func TestEnsurePluginDepsMalformedWriteError(t *testing.T) {
+	dir := t.TempDir()
+	os.WriteFile(filepath.Join(dir, "package.json"), []byte(`not json`), 0o644)
+
+	old := writeFile
+	writeFile = func(name string, data []byte, perm os.FileMode) error {
+		if strings.HasSuffix(name, "package.json") {
+			return fmt.Errorf("disk full")
+		}
+		return old(name, data, perm)
+	}
+	t.Cleanup(func() { writeFile = old })
+
+	var buf bytes.Buffer
+	err := ensurePluginDeps(dir, &buf)
+	if err == nil {
+		t.Fatal("expected write error")
+	}
+	if !strings.Contains(err.Error(), "write plugin dependencies") {
+		t.Errorf("error = %q, want 'write plugin dependencies'", err)
+	}
+	if !strings.Contains(buf.String(), "malformed") {
+		t.Error("expected malformed warning")
+	}
+}
+
+func TestEnsurePluginDepsMergeWriteError(t *testing.T) {
+	dir := t.TempDir()
+	os.WriteFile(filepath.Join(dir, "package.json"),
+		[]byte(`{"dependencies":{"other":"1.0.0"}}`), 0o644)
+
+	old := writeFile
+	writeFile = func(name string, data []byte, perm os.FileMode) error {
+		if strings.HasSuffix(name, "package.json") {
+			return fmt.Errorf("disk full")
+		}
+		return old(name, data, perm)
+	}
+	t.Cleanup(func() { writeFile = old })
+
+	err := ensurePluginDeps(dir, &bytes.Buffer{})
+	if err == nil {
+		t.Fatal("expected write error")
+	}
+	if !strings.Contains(err.Error(), "write plugin dependencies") {
+		t.Errorf("error = %q, want 'write plugin dependencies'", err)
+	}
+}
+
+func TestEnsurePluginDepsReadError(t *testing.T) {
+	dir := t.TempDir()
+	pkgPath := filepath.Join(dir, "package.json")
+	os.MkdirAll(pkgPath, 0o755)
+
+	err := ensurePluginDeps(dir, &bytes.Buffer{})
+	if err == nil {
+		t.Fatal("expected read error")
+	}
+	if !strings.Contains(err.Error(), "read plugin dependencies") {
+		t.Errorf("error = %q, want 'read plugin dependencies'", err)
+	}
+}
+
+func TestCmdSetupPluginNoDepsKeyInPackageJSON(t *testing.T) {
+	dir := t.TempDir()
+	oldHome := os.Getenv("HOME")
+	os.Setenv("HOME", dir)
+	t.Cleanup(func() { os.Setenv("HOME", oldHome) })
+
+	oldWd, _ := os.Getwd()
+	os.Chdir(dir)
+	t.Cleanup(func() { os.Chdir(oldWd) })
+
+	// package.json exists but has no "dependencies" key.
+	configDir := filepath.Join(dir, ".config", "opencode")
+	os.MkdirAll(configDir, 0o755)
+	os.WriteFile(filepath.Join(configDir, "package.json"),
+		[]byte(`{"private": true}`), 0o644)
+
+	restore := mockForm("opencode", "global")
+	defer restore()
+
+	var buf bytes.Buffer
+	err := cmdSetup(nil, &buf)
+	if err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+
+	pkgData, _ := os.ReadFile(filepath.Join(configDir, "package.json"))
+	content := string(pkgData)
+	if !strings.Contains(content, "@opencode-ai/plugin") {
+		t.Error("package.json missing plugin dependency")
+	}
+	if !strings.Contains(content, `"private"`) {
+		t.Error("package.json lost existing keys")
+	}
+}
+
+// --- content sync tests ---
+
+func TestPluginContentMatchesSourceFile(t *testing.T) {
+	t.Parallel()
+	data, err := os.ReadFile("../../.opencode/plugins/sediment.ts")
+	if err != nil {
+		t.Fatalf("read plugin source file: %v", err)
+	}
+	if string(data) != pluginContent {
+		t.Errorf("pluginContent Go constant is out of sync with .opencode/plugins/sediment.ts")
+	}
+}
+
+func TestPluginPkgJSONMatchesSourceFile(t *testing.T) {
+	t.Parallel()
+	data, err := os.ReadFile("../../.opencode/package.json")
+	if err != nil {
+		t.Fatalf("read package.json source file: %v", err)
+	}
+
+	var source, embedded map[string]any
+	if err := json.Unmarshal(data, &source); err != nil {
+		t.Fatalf("parse source package.json: %v", err)
+	}
+	if err := json.Unmarshal([]byte(pluginPkgJSON), &embedded); err != nil {
+		t.Fatalf("parse pluginPkgJSON constant: %v", err)
+	}
+
+	// The source file may have extra dev-only fields (scripts, devDependencies)
+	// but the dependency versions and private flag must stay in sync.
+	sourceDeps, _ := json.Marshal(source["dependencies"])
+	embeddedDeps, _ := json.Marshal(embedded["dependencies"])
+	if string(sourceDeps) != string(embeddedDeps) {
+		t.Errorf("dependencies out of sync:\n  source:   %s\n  embedded: %s", sourceDeps, embeddedDeps)
+	}
+	if source["private"] != embedded["private"] {
+		t.Errorf("private field out of sync: source=%v, embedded=%v", source["private"], embedded["private"])
 	}
 }
 


### PR DESCRIPTION
The OpenCode plugin only worked inside the sediment repo itself — useless for its actual purpose of providing cross-session memory in any project.

`sediment setup` now installs the plugin globally to `~/.config/opencode/` so it runs in every OpenCode session. The plugin gates on `.sediment.db` existence, so repos that haven't been set up are completely unaffected. Setup merges the plugin dependency into any existing `package.json` without clobbering other entries.

Closes #17